### PR TITLE
add:サインアウト機能を追加しました

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@ class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
 
-  def current_user
-    @current_user ||= User.find_by(id: session[:user_id]) if session[:user_id]
+  def after_sign_out_path_for(resource_or_scope)
+    root_path
   end
 end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -1,2 +1,0 @@
-class UserSessionsController < ApplicationController
-end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -5,12 +5,10 @@ skip_before_action :verify_authenticity_token, only: :steam
     @user = User.from_omniauth(request.env['omniauth.auth'])
 
     if @user.persisted?
-      session[:user_id] = @user.id
-      flash[:notice] = 'サインインに成功しました'
-      redirect_to user_path(@user)
+      sign_in(:user, @user)
+      redirect_to after_sign_in_path_for(@user)
     else
-      flash[:alert] = 'サインインに失敗しました'
-      redirect_to root_path
+      redirect_to root_path, alert: @user.errors.full_messages.join("\n")
     end
   end
 

--- a/app/views/layouts/_header.slim
+++ b/app/views/layouts/_header.slim
@@ -1,0 +1,4 @@
+p ヘッダー
+- if user_signed_in?
+  = link_to current_user.name, "#"
+  = link_to " ログアウト", destroy_user_session_path, data: {turbo_method: :delete}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,6 +18,7 @@
   </head>
 
   <body>
+    <%= render "layouts/header" %>
     <%= yield %>
   </body>
 </html>

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -1,5 +1,3 @@
-p = current_user.name
-
 p あなたの積みゲー総額は
 p ￥〇〇〇〇〇〇
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -78,6 +78,8 @@ Rails.application.configure do
   # caching is enabled.
   config.action_mailer.perform_caching = false
 
+  config.action_mailer.default_url_options = { host: 'graduation-app-kjas.onrender.com' }
+
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,9 +6,13 @@ Rails.application.routes.draw do
 
   resource :user, only: %i[show]
 
+  #devise_forで生成するルーティングのうち、DELETE /users/sign_outを上書きして、HTTP DELETEリクエストを受け取るようにする
+  #（今回は:database_authenticatableが不要だが、ログアウトのルーティングが生成されていないため）
+  devise_scope :user do
+    delete 'users/sign_out', to: 'devise/sessions#destroy', as: :destroy_user_session
+  end
+
   get 'loading', to: 'users#loading'
 
   resource :statistic, only: %i[show]
-
-  resource :user_session, only: %i[new create destroy]
 end


### PR DESCRIPTION
以下追加・変更内容です。

■ 追加・変更
- ヘッダーにサインイン中のユーザーのユーザー名と、サインアウト用のリンクを追加しました
- ヘッダーのプレースホルダーを追加しました
- サインイン処理をdeviseのメソッドを使用して行うよう変更しました
  - deviseによる実装に統一するため
- routesにサインアウト用の記載を追加しました
  - :database_authenticatableが不要で記載していないが、その影響で生成されないため

■ 削除
- application_controllerに定義していたcurrent_userメソッドを削除しました
  - devise導入により自動的に同名メソッドが作られるのに、自作の方が参照されてエラーが出てしまうため
- app/controllers/user_sessions_controller.rb を削除しました
  - devise使用につき不要なため