### PR TITLE
add:ゲームライブラリの取得機能を追加しました

### DIFF
--- a/app/controllers/game_libraries_controller.rb
+++ b/app/controllers/game_libraries_controller.rb
@@ -2,5 +2,15 @@ class GameLibrariesController < ApplicationController
   def index
     steam_service = SteamService.new
     @user_game_libraries = steam_service.get_owned_games(current_user.uid)
+
+    @user_game_libraries.each do |data|
+      game = Game.find_or_create_by_steam_app_id(data['appid'], data['name'])
+      current_user.user_game_libraries.create(game_id: game.id, minutes_played: data['playtime_forever'] || 0)
+
+      library = current_user.user_game_libraries.find_or_initialize_by(game_id: game.id)
+      library.minutes_played = data['playtime_forever'] || 0
+      library.save!
+    end
+    @user_game_libraries = current_user.user_game_libraries.includes(:game)
   end
 end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -5,4 +5,12 @@ class Game < ApplicationRecord
   validates :game_title, presence: true
   validates :steam_app_id, presence: true, uniqueness: true
   validates :price, numericality: { greater_than_or_equal_to: 0 }
+
+  def self.find_or_create_by_steam_app_id(steam_app_id, game_title)
+    game = Game.find_or_create_by(steam_app_id: steam_app_id) do |g|
+      g.game_title = game_title
+      g.price = 0 # デフォルト価格を0に設定
+    end
+    game
+  end
 end

--- a/app/services/steam_service.rb
+++ b/app/services/steam_service.rb
@@ -11,7 +11,8 @@ class SteamService
       query: {
         key: @api_key,
         steamid: steam_id,
-        include_appinfo: true
+        include_appinfo: true,
+        include_played_free_games: true
       }
     }
     response = self.class.get('/IPlayerService/GetOwnedGames/v1/', options)

--- a/app/views/game_libraries/index.slim
+++ b/app/views/game_libraries/index.slim
@@ -1,7 +1,7 @@
-- @user_game_libraries.each do |game|
+- @user_game_libraries.each do |library|
     .game
       .game-info
         .game-name
-          = game['name']
+          = library.game.game_title
         .game-playtime
-          = "プレイ時間: #{(game['playtime_forever'] / 60.0).round(2)}時間"
+          = "プレイ時間: #{(library.minutes_played / 60.0).round(2)}時間"


### PR DESCRIPTION
以下追加内容詳細です。

- gameモデルに、ゲームごとのidをテーブルに保存するメソッドの作成
- game_libraries_controller indexアクションに、APIから取得したゲームライブラリを上記メソッドを使用してgameおよびuser_game_librariesにレコードを保存する内容の追加
- コントローラーの記載変更に伴い、ビュー上のゲーム一覧とプレイ時間の表示ロジックの変更
- steam APIからの取得内容に、無料ゲームの取得の追加