### PR TITLE
add:ゲームごとの価格取得機能の追加

### DIFF
--- a/app/controllers/game_libraries_controller.rb
+++ b/app/controllers/game_libraries_controller.rb
@@ -5,7 +5,6 @@ class GameLibrariesController < ApplicationController
 
     @user_game_libraries.each do |data|
       game = Game.find_or_create_by_steam_app_id(data['appid'], data['name'])
-      current_user.user_game_libraries.create(game_id: game.id, minutes_played: data['playtime_forever'] || 0)
 
       library = current_user.user_game_libraries.find_or_initialize_by(game_id: game.id)
       library.minutes_played = data['playtime_forever'] || 0

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -13,4 +13,10 @@ class Game < ApplicationRecord
     end
     game
   end
+
+  def self.update_price_from_steam_spy(steam_app_id)
+    steam_spy_service = SteamSpyService.new
+    game_info = steam_spy_service.get_game_info(steam_app_id)
+    update(price: game_info['price'])
+  end
 end

--- a/app/services/steam_api_service.rb
+++ b/app/services/steam_api_service.rb
@@ -1,0 +1,17 @@
+class SteamApiService
+  include HTTParty
+  base_uri 'https://store.steampowered.com/api'
+
+  def get_game_price(app_id)
+    response = self.class.get("appdetails", query: {
+      appids: app_id,
+      cc: 'jp',
+      filters: 'price_overview'
+    })
+
+    data = response.parsed_response.dig(app_id.to_s, 'data', 'price_overview', 'final')
+    return nil unless data
+
+    data / 100.0
+  end
+end

--- a/app/services/steam_service.rb
+++ b/app/services/steam_service.rb
@@ -18,7 +18,7 @@ class SteamService
     response = self.class.get('/IPlayerService/GetOwnedGames/v1/', options)
 
     if response.success?
-      response.parsed_response['response']['games'] || []
+      response.parsed_response.dig('response', 'games') || []
     else
       []
     end


### PR DESCRIPTION
steamAPIよりゲームごとの価格を取得する処理を追加しました。
ゲームライブラリ取得とは異なるAPIのためクラスを分けています。

追加
- app/services/steam_api_service.rb の追加
  - gamesn > steam_app_id から価格を取得するメソッドを記載しています
- app/models/game.rb にテーブルに価格情報を反映するメソッドを記載しています
  - 名称等要修正

修正
- game_libraries_controllerにて ゲームidおよびプレイ時間の取得処理が重複していたため修正しました
- app/services/steam_service.rbにて responseから値を取り出す方法をdigに修正しました
  - 値にnilが含まれていた場合のクラッシュを防ぐため