### PR TITLE
Feature/21 save prices to games table

### DIFF
--- a/app/controllers/game_libraries_controller.rb
+++ b/app/controllers/game_libraries_controller.rb
@@ -9,6 +9,8 @@ class GameLibrariesController < ApplicationController
       library = current_user.user_game_libraries.find_or_initialize_by(game_id: game.id)
       library.minutes_played = data['playtime_forever'] || 0
       library.save!
+
+      UpdateGamePriceJob.perform_now(game.steam_app_id) if game.price.nil?
     end
     @user_game_libraries = current_user.user_game_libraries.includes(:game)
   end

--- a/app/jobs/update_game_price_job.rb
+++ b/app/jobs/update_game_price_job.rb
@@ -1,0 +1,11 @@
+class UpdateGamePriceJob < ApplicationJob
+  queue_as :default
+
+  def perform(steam_app_id)
+    game = Game.find_by(steam_app_id: steam_app_id)
+    return unless game
+
+    price = SteamApiService.new.get_game_price(steam_app_id)
+    game.update(price: price)
+  end
+end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -4,19 +4,13 @@ class Game < ApplicationRecord
 
   validates :game_title, presence: true
   validates :steam_app_id, presence: true, uniqueness: true
-  validates :price, numericality: { greater_than_or_equal_to: 0 }
+  validates :price, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
 
   def self.find_or_create_by_steam_app_id(steam_app_id, game_title)
     game = Game.find_or_create_by(steam_app_id: steam_app_id) do |g|
       g.game_title = game_title
-      g.price = 0 # デフォルト価格を0に設定
+      g.price = nil
     end
     game
-  end
-
-  def self.update_price_from_steam_spy(steam_app_id)
-    steam_spy_service = SteamSpyService.new
-    game_info = steam_spy_service.get_game_info(steam_app_id)
-    update(price: game_info['price'])
   end
 end

--- a/app/services/steam_api_service.rb
+++ b/app/services/steam_api_service.rb
@@ -9,9 +9,9 @@ class SteamApiService
       filters: 'price_overview'
     })
 
-    data = response.parsed_response.dig(steam_app_id.to_s, 'data', 'price_overview', 'final')
-    return nil unless data
+    data = response.parsed_response.dig(steam_app_id.to_s, 'data')
+    return nil unless data.is_a?(Hash)
 
-    data / 100.0
+    data.dig('price_overview', 'final')
   end
 end

--- a/app/services/steam_api_service.rb
+++ b/app/services/steam_api_service.rb
@@ -2,14 +2,14 @@ class SteamApiService
   include HTTParty
   base_uri 'https://store.steampowered.com/api'
 
-  def get_game_price(app_id)
-    response = self.class.get("appdetails", query: {
-      appids: app_id,
+  def get_game_price(steam_app_id)
+    response = self.class.get("/appdetails", query: {
+      appids: steam_app_id,
       cc: 'jp',
       filters: 'price_overview'
     })
 
-    data = response.parsed_response.dig(app_id.to_s, 'data', 'price_overview', 'final')
+    data = response.parsed_response.dig(steam_app_id.to_s, 'data', 'price_overview', 'final')
     return nil unless data
 
     data / 100.0

--- a/db/migrate/20260418122619_add_unique_index_to_games.rb
+++ b/db/migrate/20260418122619_add_unique_index_to_games.rb
@@ -1,0 +1,6 @@
+class AddUniqueIndexToGames < ActiveRecord::Migration[7.2]
+  def change
+    add_index :games, :steam_app_id, unique: true
+    add_index :user_game_libraries, [:user_id, :game_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_11_110551) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_18_122619) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -58,6 +58,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_11_110551) do
     t.integer "price"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["steam_app_id"], name: "index_games_on_steam_app_id", unique: true
   end
 
   create_table "outfit_items", force: :cascade do |t|
@@ -89,6 +90,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_11_110551) do
     t.datetime "updated_at", null: false
     t.bigint "game_id", null: false
     t.index ["game_id"], name: "index_user_game_libraries_on_game_id"
+    t.index ["user_id", "game_id"], name: "index_user_game_libraries_on_user_id_and_game_id", unique: true
     t.index ["user_id"], name: "index_user_game_libraries_on_user_id"
   end
 

--- a/spec/jobs/update_game_price_job_spec.rb
+++ b/spec/jobs/update_game_price_job_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe UpdateGamePriceJob, type: :job do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
ゲームの定価をSteam Store APIから取得し、Gamesテーブルに保存する機能を追加しました

追加
- app/services/steam_api_service.rb
  Steam Store APIからゲームの定価を取得するServiceクラスを追加しました
- app/jobs/update_game_price_job.rb
  価格取得処理をJobとして切り出しました（将来的な非同期化を見据えた設計）
- db/migrate/xxxx_add_unique_index_to_games.rb
  重複レコード防止のため、gamesテーブルのsteam_app_idと
  user_game_librariesテーブルの[user_id, game_id]にユニークインデックスを追加しました

変更
- app/controllers/game_libraries_controller.rb
  ライブラリ取得時に価格取得Jobを呼び出す処理を追加しました
- app/models/game.rb
  無料ゲームはAPIからnilが返るため、priceのデフォルトをnilに変更し
  バリデーションにallow_nil: trueを追加しました