### PR TITLE
fix:link_from_steam_login_and_others

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,10 @@ class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
 
+  def after_sign_in_path_for(resource)
+    loading_path
+  end
+
   def after_sign_out_path_for(resource_or_scope)
     root_path
   end

--- a/app/controllers/loading_controller.rb
+++ b/app/controllers/loading_controller.rb
@@ -1,5 +1,5 @@
-class GameLibrariesController < ApplicationController
-  def index
+class LoadingController < ApplicationController
+  def loading
     steam_service = SteamService.new
     @user_game_libraries = steam_service.get_owned_games(current_user.uid)
 
@@ -16,5 +16,6 @@ class GameLibrariesController < ApplicationController
       UpdateGamePriceJob.perform_now(game.steam_app_id) if game.price.nil?
     end
     @user_game_libraries = current_user.user_game_libraries.includes(:game)
+    redirect_to user_path
   end
 end

--- a/app/helpers/loading_helper.rb
+++ b/app/helpers/loading_helper.rb
@@ -1,0 +1,2 @@
+module LoadingHelper
+end

--- a/app/views/game_libraries/index.slim
+++ b/app/views/game_libraries/index.slim
@@ -1,7 +1,0 @@
-- @user_game_libraries.each do |library|
-    .game
-      .game-info
-        .game-name
-          = library.game.game_title
-        .game-playtime
-          = "プレイ時間: #{(library.minutes_played / 60.0).round(2)}時間"

--- a/app/views/layouts/_header.slim
+++ b/app/views/layouts/_header.slim
@@ -1,4 +1,4 @@
 p ヘッダー
 - if user_signed_in?
-  = link_to current_user.name, "#"
+  = current_user.name
   = link_to " ログアウト", destroy_user_session_path, data: {turbo_method: :delete}

--- a/app/views/statistics/show.html.slim
+++ b/app/views/statistics/show.html.slim
@@ -5,6 +5,8 @@ p
   = number_to_currency(@total_price, precision: 0, unit: '¥')
 p 積みゲー本数: #{@unplayed_games.count}
 
+= link_to "積みゲー総額へ戻る", user_path
+
 p
   | 積みゲーリスト:
 ul

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
     delete 'users/sign_out', to: 'devise/sessions#destroy', as: :destroy_user_session
   end
 
-  get 'loading', to: 'users#loading'
+  get 'loading', to: 'loading#loading'
 
   resource :statistic, only: %i[show]
 end

--- a/spec/helpers/loading_helper_spec.rb
+++ b/spec/helpers/loading_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the LoadingHelper. For example:
+#
+# describe LoadingHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe LoadingHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/loading_spec.rb
+++ b/spec/requests/loading_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Loadings", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
主にリンクの追加および修正を行いました。

- steamからのログイン時、ローディングアクションを挟んでから総額表示ページに遷移するよう変更しました
  - rootに遷移していたため
- ゲームライブラリ一覧表示ページを削除しました
  - ライブラリおよび価格取得処理をloadingアクションに移したため
- 積みゲー統計ページから総額ページへ遷移するリンクを追加しました