### PR TITLE
add:unplayed_price_rankings_and_cleared_rate

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -2,6 +2,6 @@ class StaticPagesController < ApplicationController
   skip_before_action :authenticate_user!
 
   def top
-    @users = User.all.sort_by { |user| -UserGameLibrary.total_games_count(user) }.first(User::TOP_PAGE_USER_RANKINGS)
+    @unplayed_price_and_count_ranking_users = User.all.map { |user| [user, UserGameLibrary.total_price(user), UserGameLibrary.total_games_count(user)]}.sort_by { |data| -data[1] }.first(User::TOP_PAGE_USER_RANKINGS)
   end
 end

--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -6,6 +6,8 @@ class StatisticsController < ApplicationController
     @recommended_games = current_user.user_game_libraries.unplayed.cheapest_games.recommend_3
     @cleared_after_unplayed_games = current_user.user_game_libraries.cleared_after_unplayed.includes(:game)
 
+    @cleared_game_count_rate = UserGameLibrary.cleared_game_count_rate(current_user)
+
     game_genres = UserGameLibrary.unplayed_game_genres(current_user)
     max_count = game_genres.map{ |x| x[1] }.max
     min_count = game_genres.map{ |x| x[1] }.min

--- a/app/models/user_game_library.rb
+++ b/app/models/user_game_library.rb
@@ -54,4 +54,8 @@ class UserGameLibrary < ApplicationRecord
     genre_names = libraries.flat_map { |library| library.game.game_genre_types.map { |genre| genre.name } }
     genre_names.tally.sort_by{ |x| x[1] }
   end
+
+  def self.cleared_game_count_rate(user)
+    user.user_game_libraries.where.not(cleared_date: nil).count.to_f / user.user_game_libraries.count.to_f * 100
   end
+end

--- a/app/views/static_pages/top.html.slim
+++ b/app/views/static_pages/top.html.slim
@@ -10,9 +10,9 @@ div.container style="margin-top: 10rem;"
             li 積みゲー消化サポート機能
             li 積みゲー消化推移（実装予定）
 
-    h2.text-center.pb-3 style="margin-top: 3rem;" 積みゲー本数ランキング
+    h2.text-center.pb-3 style="margin-top: 3rem;" 積みゲー金額ランキング
 
     div.d-flex.justify-content-center
         ol
-            - @users.each do |user|
-                li = "#{user.name} #{UserGameLibrary.total_games_count(user)}本"
+            - @unplayed_price_and_count_ranking_users.each do |user_price_count|
+                li = "¥#{user_price_count[1]} (#{user_price_count[2]}本)"

--- a/app/views/statistics/show.html.slim
+++ b/app/views/statistics/show.html.slim
@@ -4,6 +4,7 @@ div.card.text-white.w-50.border-0.mx-auto.mt-5
   div.card-body.card-body-color.d-flex
     p.me-4 積みゲー総額: #{number_to_currency(@total_price, precision: 0, unit: '¥')}
     p.me-4 積みゲー本数: #{@unplayed_games.count}
+    p.me-4 全体消化率: #{@cleared_game_count_rate.round(2)}%
 
 div.card.text-white.w-50.border-0.mx-auto.mt-5
   div.card-header.card-header-color.pb-0


### PR DESCRIPTION
- トップページに積みゲー金額ランキング表示を追加しました
  - ユーザー名は非公開にしています
  - また、積みゲー本数ランキングを削除し、金額ランキングに統合しました
- また、消化率ランキングも掲載予定でしたがこれを取りやめ、個人の統計ページに消化率表示を追加しました