### PR TITLE
add:give_gift_to_user_character_feature

### DIFF
--- a/app/controllers/gift_items_controller.rb
+++ b/app/controllers/gift_items_controller.rb
@@ -1,0 +1,28 @@
+class GiftItemsController < ApplicationController
+    before_action :set_user_character
+
+    def index
+        @user_gift_items = current_user.user_gift_items
+    end
+
+    def show
+        @user_gift_item = current_user.user_gift_items.find(params[:id])
+    end
+
+    def present_gift
+        gift_item = GiftItem.find(params[:gift_item_id])
+        count = params[:count].to_i
+        GiftItem.present_gift_process(current_user, @user_character, gift_item, count)
+        @current_user_gift_item = current_user.user_gift_items.find_by(gift_item_id: gift_item.id)
+    end
+
+    private
+
+    def set_user_character
+        @user_character = current_user.user_characters.find(params[:user_character_id])
+        @page = 'user_characters_gift_show'
+        @total_price = UserGameLibrary.total_price(current_user)
+        @character_text = CharacterTextService.new.get_character_text(@user_character, @page, @total_price)
+        @character_expression = @character_text.character_expression
+    end
+end

--- a/app/helpers/gift_items_helper.rb
+++ b/app/helpers/gift_items_helper.rb
@@ -1,0 +1,2 @@
+module GiftItemsHelper
+end

--- a/app/javascript/controllers/gift_modal_controller.js
+++ b/app/javascript/controllers/gift_modal_controller.js
@@ -1,0 +1,8 @@
+import * as bootstrap from "bootstrap"
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+    close() {
+        bootstrap.Modal.getInstance(this.element).hide()
+    }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,5 +4,8 @@
 
 import { application } from "./application"
 
+import GiftModalController from "./gift_modal_controller"
+application.register("gift-modal", GiftModalController)
+
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)

--- a/app/models/gift_item.rb
+++ b/app/models/gift_item.rb
@@ -3,4 +3,12 @@ class GiftItem < ApplicationRecord
     has_many :users, through: :user_gift_items
     has_many :task_rewards, as: :item, dependent: :destroy
     has_many :shop_items, as: :item, dependent: :destroy
+
+    def self.present_gift_process(user, user_character, gift_item, count)
+        ActiveRecord::Base.transaction do
+            possessed_user_gift_item = user.user_gift_items.find_by(gift_item_id: gift_item.id)
+            possessed_user_gift_item.decrement!(:quantity, count)
+            user_character.increment!(:friendship_point, gift_item.friendship_point*count)
+        end
+    end
 end

--- a/app/models/user_character.rb
+++ b/app/models/user_character.rb
@@ -6,9 +6,15 @@ class UserCharacter < ApplicationRecord
   validates :name, presence: true
   validates :friendship_point, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
 
+  FRIENDSHIP_LEVEL_THRESHOLDS = { 1 => 0, 2 => 50, 3 => 100 }.freeze
+
   def self.find_or_create_default_character(user)
     find_or_create_by!(user_id: user.id, character_type_id: CharacterType.find_by(name: 'いらすと子').id) do |uc|
       uc.name = '仮'
     end
+  end
+
+  def current_friendship_level
+    FRIENDSHIP_LEVEL_THRESHOLDS.select {|level, required_point| required_point <= friendship_point }.keys.max
   end
 end

--- a/app/services/character_text_service.rb
+++ b/app/services/character_text_service.rb
@@ -1,7 +1,7 @@
 class CharacterTextService
   def get_character_text(user_character, page, total_price)
     character_type = user_character.character_type
-    condition = CharacterTextCondition.where(character_type_id: character_type.id).where(page: page).where('min_price <= ? AND (max_price IS NULL OR max_price >= ? )', total_price, total_price).first
+    condition = CharacterTextCondition.where(character_type_id: character_type.id).where(page: page).where('min_price <= ? AND (max_price IS NULL OR max_price >= ? )', total_price, total_price).where('friendship_level <= ?', user_character.current_friendship_level).order(friendship_level: :desc).first
     text = condition.character_texts.sample
   end
 end

--- a/app/views/gift_items/index.html.slim
+++ b/app/views/gift_items/index.html.slim
@@ -1,0 +1,32 @@
+div.container
+  div.d-flex.justify-content-between.align-items-center.mb-3
+    = link_to '< 戻る', user_character_path(@user_character), class: 'btn btn-secondary text-white rounded-pill px-4'
+
+  div.row
+    div.col-4.text-center
+      = image_tag(@user_character.character_type.image_path, alt: @user_character.name, width: 200)
+
+    div#dom_id
+      p 初期表示用テキストだよ～
+
+    div.col-8
+      - @user_gift_items.each do |user_gift_item|
+        div.list-group-item.d-flex.justify-content-between.align-items-center.py-3.text-white.mb-2 data-bs-toggle="modal" data-bs-target="#gift_modal_#{user_gift_item.id}"
+          span id="gift_item_#{user_gift_item.id}" = "#{user_gift_item.gift_item.name}（所持数：#{user_gift_item.quantity}）"
+
+        div.modal.fade id="gift_modal_#{user_gift_item.id}" tabindex="-1" data-controller="gift-modal"
+          div.modal-dialog
+            div.modal-content
+              div.modal-header
+                h5.modal-title = user_gift_item.gift_item.name
+                button.btn-close type="button" data-bs-dismiss="modal" aria-label="Close"
+              div.modal-body
+                p = user_gift_item.gift_item.description
+                = form_with url: present_gift_user_character_gift_items_path(@user_character), method: :patch, data: { action: 'turbo:submit-end->gift-modal#close' } do |f|
+                  = f.hidden_field :gift_item_id, value: user_gift_item.gift_item_id
+                  div.mb-3
+                    label.form-label 個数
+                    = f.number_field :count, value: 1, min: 1, max: user_gift_item.quantity, class: 'form-control'
+                  div.d-flex.justify-content-end.gap-2
+                    button.btn.btn-secondary type="button" data-bs-dismiss="modal" やめておく
+                    = f.submit 'プレゼントする', class: 'btn btn-primary'

--- a/app/views/gift_items/present_gift.turbo_stream.slim
+++ b/app/views/gift_items/present_gift.turbo_stream.slim
@@ -1,0 +1,6 @@
+= turbo_stream.replace 'dom_id' do
+  div#dom_id
+    p #{@character_text.text}
+
+= turbo_stream.replace "gift_item_#{@current_user_gift_item.id}" do 
+    span = "#{@current_user_gift_item.gift_item.name}（所持数：#{@current_user_gift_item.quantity}）"

--- a/app/views/gift_items/show.html.slim
+++ b/app/views/gift_items/show.html.slim
@@ -1,0 +1,7 @@
+div.container
+  div.d-flex.justify-content-between.align-items-center.mb-3
+    = link_to '< 戻る', user_character_gift_items_path(@user_character), class: 'btn btn-secondary text-white rounded-pill px-4'
+
+  h1.text-white = @user_gift_item.gift_item.name
+  p.text-white = @user_gift_item.gift_item.description
+  p.text-white 所持数：#{@user_gift_item.quantity}

--- a/app/views/user_characters/show.html.slim
+++ b/app/views/user_characters/show.html.slim
@@ -5,9 +5,9 @@ div.container.text-center
     = image_tag(@user_character.character_type.image_path, alt: @user_character.name, width: 300)
 
   div#dom_id
-    p.text-white テキスト表示テスト
+    p.text-white #{@character_text.text}
 
   div.d-flex.justify-content-center.gap-3.mt-4
-    = link_to 'プレゼントを渡す', '#', class: 'btn btn-secondary text-white rounded-4 px-4 py-3'
+    = link_to 'プレゼントを渡す', user_character_gift_items_path(@user_character), class: 'btn btn-secondary text-white rounded-4 px-4 py-3'
     = link_to '話す', communicate_user_character_path, data: { turbo_stream: true }, class: 'btn btn-secondary text-white rounded-4 px-4 py-3'
     = link_to '衣装を変更する', '#', class: 'btn btn-secondary text-white rounded-4 px-4 py-3'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,5 +38,10 @@ Rails.application.routes.draw do
     member do
       get 'communicate'
     end
+    resources :gift_items, only: %i[index show] do
+      collection do
+        patch 'present_gift'
+      end
+    end
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,18 +3,30 @@ character_type = CharacterType.find_or_create_by!(name: 'いらすと子') do |c
   ct.image_path = 'https://res.cloudinary.com/dvswzgioa/image/upload/q_auto/f_auto/v1777086275/business_woman1_1_smile_ujoauq.png'
 end
 
-# 総額ごとのconditions
-condition_show_min = CharacterTextCondition.find_or_create_by!(character_type_id: character_type.id, page: 'users_show', friendship_level: 1, min_price: 0, max_price: 0)
+# 状況ごとのconditions
+## 総額
+condition_show_min = CharacterTextCondition.find_or_initialize_by(character_type_id: character_type.id, page: 'users_show', min_price: 0, max_price: 0)
+condition_show_min.update!(friendship_level: 1)
 
-condition_show_low = CharacterTextCondition.find_or_create_by!(character_type_id: character_type.id, page: 'users_show', friendship_level: 1, min_price: 1, max_price: 5000)
+condition_show_low = CharacterTextCondition.find_or_initialize_by(character_type_id: character_type.id, page: 'users_show', min_price: 1, max_price: 5000)
+condition_show_low.update!(friendship_level: 1)
 
-condition_show_med = CharacterTextCondition.find_or_create_by!(character_type_id: character_type.id, page: 'users_show', friendship_level: 1, min_price: 5001, max_price: 10000)
+condition_show_med = CharacterTextCondition.find_or_initialize_by(character_type_id: character_type.id, page: 'users_show', min_price: 5001, max_price: 10000)
+condition_show_med.update!(friendship_level: 1)
 
-condition_show_high = CharacterTextCondition.find_or_create_by!(character_type_id: character_type.id, page: 'users_show', friendship_level: 1, min_price: 10001, max_price: 30000)
+condition_show_high = CharacterTextCondition.find_or_initialize_by(character_type_id: character_type.id, page: 'users_show', min_price: 10001, max_price: 30000)
+condition_show_high.update!(friendship_level: 1)
 
-condition_show_max = CharacterTextCondition.find_or_create_by!(character_type_id: character_type.id, page: 'users_show', friendship_level: 1, min_price: 30001, max_price: nil)
+condition_show_max = CharacterTextCondition.find_or_initialize_by(character_type_id: character_type.id, page: 'users_show', min_price: 30001, max_price: nil)
+condition_show_max.update!(friendship_level: 1)
 
-condition_communicate_show = CharacterTextCondition.find_or_create_by!(character_type_id: character_type.id, page: 'user_characters_show', friendship_level: 1, min_price: 0, max_price: 999999999)
+## キャラ詳細ページ用
+condition_communicate_show = CharacterTextCondition.find_or_initialize_by(character_type_id: character_type.id, page: 'user_characters_show', min_price: 0, max_price: 999999999)
+condition_communicate_show.update!(friendship_level: 1)
+
+## ギフトページ用
+condition_gift_show = CharacterTextCondition.find_or_initialize_by(character_type_id: character_type.id, page: 'user_characters_gift_show', min_price: 0, max_price: 999999999)
+condition_gift_show.update!(friendship_level: 1)
 
 # 表情差分
 expression_neutral = CharacterExpression.find_or_create_by!(character_type_id: character_type.id, emotion_type: 'neutral') do |ce|
@@ -75,6 +87,10 @@ ct = CharacterText.find_or_create_by!(character_text_condition_id: condition_com
 end
 
 ct = CharacterText.find_or_create_by!(character_text_condition_id: condition_communicate_show.id, text: 'こんにちファブル！') do |ct|
+  ct.character_expression_id = expression_happy.id
+end
+
+ct = CharacterText.find_or_create_by!(character_text_condition_id: condition_gift_show.id, text: 'ありがとう！') do |ct|
   ct.character_expression_id = expression_happy.id
 end
 

--- a/spec/helpers/gift_items_helper_spec.rb
+++ b/spec/helpers/gift_items_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the GiftItemsHelper. For example:
+#
+# describe GiftItemsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe GiftItemsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/gift_items_spec.rb
+++ b/spec/requests/gift_items_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "GiftItems", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
## 概要

キャラクターへのプレゼント機能を実装しました。プレゼントを渡すと好感度が上昇し、好感度レベルに応じてキャラのセリフが変化します。

## 変更内容

### プレゼント機能（新規）

- `GiftItemsController`（`index` / `show` / `present_gift`）を追加
- ルーティングは `user_characters` にネスト（`/user_characters/:user_character_id/gift_items/...`）
- `index`：所持ギフト一覧＋所持数を表示。アイテムをクリックするとモーダルで個数選択→プレゼント実行
- `present_gift`：`GiftItem.present_gift_process`（好感度加算・所持数減算をトランザクションで実行）を呼び出し、Turbo Streamでページ遷移なしに以下を更新
  - キャラの反応セリフ
  - 一覧の所持数表示
  - モーダルを自動で閉じる（`gift_modal_controller.js` を新規追加）

### 好感度レベルによるセリフ出し分け

- `UserCharacter` に `FRIENDSHIP_LEVEL_THRESHOLDS` 定数と `current_friendship_level` メソッドを追加
  - 好感度ポイント → レベルを算出（例: `{1 => 0, 2 => 50, 3 => 100}`）
- `CharacterTextService` を、価格帯に加えて好感度レベルでも絞り込むように変更
  - 条件を満たす中で最も高いレベルのセリフが優先される
- `db/seeds.rb` にプレゼントページ用の `CharacterTextCondition` / セリフを追加


## 補足・今後の課題

- [ ] `gift_items#show`（個別アイテム詳細）は最低限のみ実装。今回のプレゼントの流れでは未使用
- [ ] 好感度レベルの3段階しきい値（`{1 => 0, 2 => 50, 3 => 100}`）は仮の値。バランス調整は今後の課題
- [ ] 衣装変更機能は素材未整備のため未着手