### PR TITLE
add:tooltip to gift items index

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -9,3 +9,6 @@ application.register("gift-modal", GiftModalController)
 
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
+
+import TooltipController from "./tooltip_controller"
+application.register("tooltip", TooltipController)

--- a/app/javascript/controllers/tooltip_controller.js
+++ b/app/javascript/controllers/tooltip_controller.js
@@ -1,0 +1,8 @@
+import * as bootstrap from "bootstrap"
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+    connect() {
+        new bootstrap.Tooltip(this.element)
+    }
+}

--- a/app/views/gift_items/index.html.slim
+++ b/app/views/gift_items/index.html.slim
@@ -12,7 +12,7 @@ div.container
     div.col-8
       - @user_gift_items.each do |user_gift_item|
         div.list-group-item.d-flex.justify-content-between.align-items-center.py-3.text-white.mb-2 data-bs-toggle="modal" data-bs-target="#gift_modal_#{user_gift_item.id}"
-          span id="gift_item_#{user_gift_item.id}" = "#{user_gift_item.gift_item.name}（所持数：#{user_gift_item.quantity}）"
+          span id="gift_item_#{user_gift_item.id}" data-bs-toggle="tooltip" title="#{user_gift_item.gift_item.description} +#{user_gift_item.gift_item.friendship_point}p" data-controller="tooltip" = "#{user_gift_item.gift_item.name}（所持数：#{user_gift_item.quantity}）"
 
         div.modal.fade id="gift_modal_#{user_gift_item.id}" tabindex="-1" data-controller="gift-modal"
           div.modal-dialog


### PR DESCRIPTION
## Summary

ギフト一覧のアイテムにホバーすると、説明文と好感度上昇量をtooltipで確認できるようにしました。

## 変更内容

- ギフト一覧の各アイテムに`data-bs-toggle="tooltip"`を追加し、`description`と`friendship_point`（好感度上昇量）をtooltipで表示
- Bootstrapのtooltipは自動初期化されないため、`tooltip_controller.js`（Stimulus）を新規追加
  - `connect()`のタイミングで`new bootstrap.Tooltip(this.element)`を実行し初期化
- `app/javascript/controllers/index.js`に新規コントローラを登録（`./bin/rails stimulus:manifest:update`で生成）

## 変更ファイル

| 種別 | ファイル |
|---|---|
| 新規 | `app/javascript/controllers/tooltip_controller.js` |
| 変更 | `app/views/gift_items/index.html.slim` |
| 変更 | `app/javascript/controllers/index.js` |