### PR TITLE
fix/change_concurrency_of_sidekiq_for_render

### DIFF
--- a/app/jobs/update_game_price_job.rb
+++ b/app/jobs/update_game_price_job.rb
@@ -5,7 +5,7 @@ class UpdateGamePriceJob < ApplicationJob
     game = Game.find_by(steam_app_id: steam_app_id)
     return unless game
 
-    price = SteamApiService.new.get_game_price_and_genre(steam_app_id)
-    game.update(price: price)
+    prices = SteamApiService.new.get_game_price_and_genre(steam_app_id)
+    game.update(price: prices[:price])
   end
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,1 @@
+:concurrency: 3


### PR DESCRIPTION
## summary
Render本番環境にSidekiq Worker機能を追加したところ、UpdateGamePriceJob / UpdateGameGenreJob が
NoMethodError: undefined method 'dig' for nil で大量に失敗する問題が発生していた。

## 原因
Sidekiqのデフォルト同時実行数(concurrency: 10)のまま、Steamライブラリ内の全ゲーム分の
ジョブが一斉にキューへ積まれ、Steamの非公式Store API(appdetails)に対して短時間に
大量の並列リクエストが送られていた。これによりレート制限がかかり、レスポンスが
空/非JSONとなって response.parsed_response が nil になり、.dig呼び出しで例外が発生していた。

## 対応
config/sidekiq.yml を追加し、concurrency を 3 に制限。同時に送るリクエスト数を絞ることで
Steam API側のレート制限を回避する。

## 動作確認
- [ ] Render本番環境にデプロイ
- [ ] Steamログイン後、Sidekiq Web UI(/sidekiq)でFailedジョブの発生状況を確認
- [ ] 積みゲー総額が正しく表示されることを確認