### PR TITLE
perf: fontconfigキャッシュをビルド時に事前生成

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /rails
 
 # Install base packages
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y curl libjemalloc2 libvips postgresql-client && \
+    apt-get install --no-install-recommends -y curl libjemalloc2 libvips fontconfig postgresql-client && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Set production environment
@@ -68,6 +68,10 @@ FROM base
 # Copy built artifacts: gems, application
 COPY --from=build "${BUNDLE_PATH}" "${BUNDLE_PATH}"
 COPY --from=build /rails /rails
+
+# Pre-build the fontconfig cache (including app/assets/fonts) at build time,
+# since the runtime user has no writable cache dir to build it on the fly.
+RUN fc-cache -f
 
 # Run and own only the runtime files as a non-root user for security
 RUN groupadd --system --gid 1000 rails && \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -9,8 +9,9 @@ RUN apt-get update -qq \
 && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
 && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
 && apt-get update -qq \
-&& apt-get install -y build-essential libpq-dev libvips42 nodejs vim \
-&& npm install -g yarn@1.22.22
+&& apt-get install -y build-essential libpq-dev libvips42 fontconfig nodejs vim \
+&& npm install -g yarn@1.22.22 \
+&& fc-cache -f
 
 RUN mkdir /myapp
 WORKDIR /myapp


### PR DESCRIPTION
## Summary
OGP画像生成の初回リクエストが4.7秒かかっており、opengraph.xyz等の外部クローラーが
画像取得時に502 Bad Gatewayになる不具合が疑われる。原因調査中、
"Fontconfig error: No writable cache directories" という警告が実行時に出続けて
いることを確認した。

対策として、Dockerfile / Dockerfile.devに fontconfig パッケージを追加し、
ビルド時(rootユーザーの間)に `fc-cache -f` を実行してキャッシュを事前生成するようにした。