### PR TITLE
fix: allow_browserがXのクローラーをブロックしていた不具合を修正

### DIFF
--- a/app/controllers/ogp_images_controller.rb
+++ b/app/controllers/ogp_images_controller.rb
@@ -1,4 +1,5 @@
 class OgpImagesController < ApplicationController
+    allow_browser versions: {}
     skip_before_action :authenticate_user!
 
     def show

--- a/app/controllers/user_shares_controller.rb
+++ b/app/controllers/user_shares_controller.rb
@@ -1,4 +1,5 @@
 class UserSharesController < ApplicationController
+    allow_browser versions: {}
     skip_before_action :authenticate_user!
 
     def show


### PR DESCRIPTION
## Summary
本番ログを確認したところ、実際にXのクローラー(外部IP)からのアクセスが
`Filter chain halted by allow_browser` → `406 Not Acceptable` で弾かれていたことが判明。
ApplicationControllerの`allow_browser versions: :modern`により、モダンブラウザ以外の
アクセス(Xのクローラー含む)がブロックされていた可能性が考えられる。

UserSharesController・OgpImagesControllerの両方に`allow_browser versions: {}`を追加し、
この制限を解除。ローカルでTwitterbotのUser-Agentを装ったリクエストが200 OKになることを確認済み。