### PR TITLE
add: プレイ時間/価格のコスパランキング機能を追加

### DIFF
--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -13,6 +13,15 @@ class StatisticsController < ApplicationController
     min_count = game_genres.map{ |x| x[1] }.min
     @most_unplayed_game_genres = game_genres.select{ |x| x[1] == max_count }
     @least_unplayed_game_genres = game_genres.select{ |x| x[1] == min_count }
+
+    cost_performance_ranking = UserGameLibrary.cost_performance_ranking(current_user)
+    @best_cost_performance_games = cost_performance_ranking[:best]
+    @worst_cost_performance_games = cost_performance_ranking[:worst]
+  end
+
+  def cost_performance_detailed_ranking
+    cost_performance_ranking = UserGameLibrary.cost_performance_ranking(current_user)
+    @all_cost_performance_games = cost_performance_ranking[:all]
   end
 
   def update_cleared_games

--- a/app/models/user_game_library.rb
+++ b/app/models/user_game_library.rb
@@ -3,6 +3,7 @@ class UserGameLibrary < ApplicationRecord
   CHEAPEST_GAMES_LIMIT = 10
   RECOMMENDATION_COUNT = 3
   TSUMIGE_LIST_LIMIT = 10
+  COST_PERFORMANCE_RANKING_LIMIT = 3
 
   belongs_to :user
   belongs_to :game
@@ -39,6 +40,15 @@ class UserGameLibrary < ApplicationRecord
     end
     UpdateGamePriceJob.perform_later(game.steam_app_id) if game.price.nil?
     UpdateGameGenreJob.perform_later(game.steam_app_id) if game.game_genres.empty?
+  end
+
+  def self.cost_performance_ranking(user)
+    ranked = user.user_game_libraries.includes(:game).joins(:game).where.not(games: { price: nil }).where('games.price > 0').sort_by{ |library| -((library.minutes_played + 1).to_f / library.game.price)}
+    {
+      best: ranked.first(COST_PERFORMANCE_RANKING_LIMIT),
+      worst: ranked.last(COST_PERFORMANCE_RANKING_LIMIT).reverse,
+      all: ranked
+    }
   end
 
   def self.total_price(user)

--- a/app/views/statistics/cost_performance_detailed_ranking.html.slim
+++ b/app/views/statistics/cost_performance_detailed_ranking.html.slim
@@ -1,0 +1,11 @@
+div.card.text-white.w-50.border-0.mx-auto.mt-5
+  div.card-header.card-header-color.pb-0
+    p.p-1 コスパランキング
+  div.card-body.card-body-color.d-flex
+    ol.w-100.px-3
+      - @all_cost_performance_games.each do |library|
+        li.d-flex.justify-content-between
+          span.col-6 = library.game.game_title
+          span.col-6 = "¥#{library.game.price}"
+          span.col-6 = "#{(library.minutes_played/60.0).round(1)}時間"
+          span.col-6 = "#{(((library.minutes_played + 1).to_f / library.game.price)*1000).round(2)}"

--- a/app/views/statistics/show.html.slim
+++ b/app/views/statistics/show.html.slim
@@ -62,3 +62,22 @@ div.card.text-white.w-50.border-0.mx-auto.mt-5
           span.col-6 = library.game.game_title
           span.col-6 = "#{(library.minutes_played/60.0).round(1)}時間"
           span.col-6 = "#{(library.cleared_date - library.unplayed_date).to_i}日"
+
+div.card.text-white.w-50.border-0.mx-auto.mt-5
+  div.card-header.card-header-color.pb-0
+    p.p-1 コスパランキング
+  div.card-body.card-body-color.d-flex
+    ol.w-100.px-3
+      - @best_cost_performance_games.each do |library|
+        li.d-flex.justify-content-between
+          span.col-6 = library.game.game_title
+          span.col-6 = "¥#{library.game.price}"
+          span.col-6 = "#{(library.minutes_played/60.0).round(1)}時間"
+          span.col-6 = "#{(((library.minutes_played + 1).to_f / library.game.price)*1000).round(2)}"
+      - @worst_cost_performance_games.each do |library|
+        li.d-flex.justify-content-between
+          span.col-6 = library.game.game_title
+          span.col-6 = "¥#{library.game.price}"
+          span.col-6 = "#{(library.minutes_played/60.0).round(1)}時間"
+          span.col-6 = "#{(((library.minutes_played + 1).to_f / library.game.price)*1000).round(2)}"
+      = link_to '詳細へ', cost_performance_detailed_ranking_statistic_path, class: 'btn btn-secondary text-white'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,7 @@ Rails.application.routes.draw do
   resource :statistic, only: %i[show] do
     member do
       patch 'update_cleared_games'
+      get 'cost_performance_detailed_ranking'
     end
   end
 


### PR DESCRIPTION
## Summary
統計ページに、所有ゲームを「プレイ時間 ÷ 価格」でランキングした「コスパランキング」を追加。ベスト3・ワースト3を統計ページに表示し、詳細ページで全件を確認できるようにした。

## 主な変更
- `UserGameLibrary.cost_performance_ranking(user)` を追加
  - 価格が確定している(nilでも0円でもない)ゲームを対象に、`(プレイ時間 + 1) / 価格` の降順でランキングを算出
  - 分子に+1のオフセットを入れることで、未プレイ(0時間)のゲーム同士でも価格に応じて指数が変わるようにしている(単純な プレイ時間/価格 だと未プレイは常に0になり、価格による差が出ないため)
  - nil/0円のゲームはランキング対象から除外
    - nilはperform_laterによる取得遅れ考慮
    - 0円は0除算考慮、無料ゲームはプレイ時間が大きいユーザーも多いため加えたいが、表示方法は要検討
- `StatisticsController#show` でベスト3/ワースト3を表示、新規 `cost_performance_detailed_ranking` アクションで全件表示
- ルーティングは `resource :statistic` の `member` に追加