### PR TITLE
add:マイレージポイントを使用したショップ機能

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -33,6 +33,14 @@ body {
     background-color: #4A4A4A;
 }
 
+.shop-item-owned {
+    background-color: #4A4A4A;
+}
+
+#purchase_toast .toast-body {
+    color: #1B2838;
+}
+
 .price-display {
   font-size: 10rem;
 }

--- a/app/controllers/shop_items_controller.rb
+++ b/app/controllers/shop_items_controller.rb
@@ -1,0 +1,14 @@
+class ShopItemsController < ApplicationController
+    def index
+        @user_gift_items = current_user.user_gift_items
+        @user_outfit_items = current_user.user_outfit_items
+        @owned_outfit_item_ids = @user_outfit_items.pluck(:outfit_item_id)
+        @shop_items = ShopItem.includes(:item).all
+    end
+
+    def purchase_item
+        @shop_item = ShopItem.find(params[:id])
+        @count = @shop_item.item_type == 'GiftItem' ? params[:count].to_i : 1
+        ShopItem.purchase_item_process(current_user, @shop_item, @count)
+    end
+end

--- a/app/helpers/shop_items_helper.rb
+++ b/app/helpers/shop_items_helper.rb
@@ -1,0 +1,5 @@
+module ShopItemsHelper
+  def shop_item_owned?(shop_item, owned_outfit_item_ids)
+    shop_item.item_type == 'OutfitItem' && owned_outfit_item_ids.include?(shop_item.item_id)
+  end
+end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -12,3 +12,9 @@ application.register("hello", HelloController)
 
 import TooltipController from "./tooltip_controller"
 application.register("tooltip", TooltipController)
+
+import ShopPreviewController from "./shop_preview_controller"
+application.register("shop-preview", ShopPreviewController)
+
+import ToastController from "./toast_controller"
+application.register("toast", ToastController)

--- a/app/javascript/controllers/shop_preview_controller.js
+++ b/app/javascript/controllers/shop_preview_controller.js
@@ -1,0 +1,10 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+    static targets = ["image", "description"]
+
+    show(event) {
+        this.imageTarget.src = event.params.image
+        this.descriptionTarget.textContent = event.params.description
+    }
+}

--- a/app/javascript/controllers/toast_controller.js
+++ b/app/javascript/controllers/toast_controller.js
@@ -1,0 +1,8 @@
+import * as bootstrap from "bootstrap"
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+    connect() {
+        new bootstrap.Toast(this.element).show()
+    }
+}

--- a/app/models/shop_item.rb
+++ b/app/models/shop_item.rb
@@ -1,3 +1,21 @@
 class ShopItem < ApplicationRecord
     belongs_to :item, polymorphic: true
+
+    def self.purchase_item_process(user, shop_item, quantity)
+        ActiveRecord::Base.transaction do
+            possessed_user_points = user.user_wallet
+            total_shop_items_price = shop_item.price * quantity
+            return if shop_item.item_type == "OutfitItem" && user.user_outfit_items.exists?(outfit_item_id: shop_item.item_id)
+            possessed_user_points.decrement!(:point, total_shop_items_price)
+
+            if shop_item.item_type == 'GiftItem'
+                user_gift_item = user.user_gift_items.find_or_create_by!(gift_item_id: shop_item.item.id) do |ugi|
+                    ugi.quantity = 0
+                end
+                user_gift_item.increment!(:quantity, quantity)
+            elsif shop_item.item_type == 'OutfitItem'
+                user.user_outfit_items.find_or_create_by!(outfit_item_id: shop_item.item.id)
+            end
+        end
+    end
 end

--- a/app/views/layouts/_header.slim
+++ b/app/views/layouts/_header.slim
@@ -17,7 +17,7 @@ nav.navbar.navbar-expand-lg.ps-3.fixed-top
         ul.dropdown-menu
           li
             = link_to '育成', '#', class: 'dropdown-item'
-            = link_to 'マイレージ交換', '#', class: 'dropdown-item'
+            = link_to 'マイレージ交換', shop_items_path, class: 'dropdown-item'
             = link_to 'マイレージ確認', tasks_path, class: 'dropdown-item'
 
       div.dropdown.pe-3

--- a/app/views/shop_items/index.html.slim
+++ b/app/views/shop_items/index.html.slim
@@ -1,0 +1,41 @@
+ div.container data-controller="shop-preview"
+  div.d-flex.justify-content-between.align-items-center.mb-3
+    = link_to '< 戻る', user_path(current_user), class: 'btn btn-secondary text-white rounded-pill px-4'
+    span#user_wallet_point.text-white = "#{current_user.user_wallet.point}P"
+
+  div.row
+    div.col-4.text-center.position-relative
+      - first_item = @shop_items.first&.item
+      = image_tag(first_item&.image_path, data: { shop_preview_target: 'image' }, alt: 'アイテム画像', width: 200)
+      p.text-white data-shop-preview-target="description" = first_item&.description
+      div.toast.fade.position-absolute.top-100.start-50.translate-middle-x.mt-2 id="purchase_toast" role="status" aria-live="polite" aria-atomic="true" data-bs-autohide="true" data-bs-delay="3000"
+        div.toast-body
+
+    div.col-8
+      ol.list-group
+        - @shop_items.each do |shop_item|
+          - owned = shop_item_owned?(shop_item, @owned_outfit_item_ids)
+          - if owned
+            li.list-group-item.d-flex.justify-content-between.align-items-center.py-3.mb-2.shop-item-owned
+              span = shop_item.item.name
+              span 所持済み
+          - else
+            li.list-group-item.d-flex.justify-content-between.align-items-center.py-3.mb-2 data-action="mouseover->shop-preview#show" data-bs-toggle="modal" data-bs-target="#shop_item_modal_#{shop_item.id}" data-shop-preview-image-param="#{shop_item.item.image_path}" data-shop-preview-description-param="#{shop_item.item.description}"
+              span = shop_item.item.name
+              span = "#{shop_item.price}P"
+
+            div.modal.fade id="shop_item_modal_#{shop_item.id}" tabindex="-1" data-controller="gift-modal"
+              div.modal-dialog
+                div.modal-content
+                  div.modal-header
+                    h5.modal-title = "#{shop_item.item.name}を交換しますか？"
+                    button.btn-close type="button" data-bs-dismiss="modal" aria-label="Close"
+                  div.modal-body
+                    = form_with url: purchase_item_shop_item_path(shop_item), method: :patch, data: { action: 'turbo:submit-end->gift-modal#close' } do |f|
+                      - if shop_item.item_type == 'GiftItem'
+                        div.mb-3
+                          label.form-label 個数
+                          = f.number_field :count, value: 1, min: 1, class: 'form-control'
+                      div.d-flex.justify-content-end.gap-2
+                        button.btn.btn-secondary type="button" data-bs-dismiss="modal" やめておく
+                        = f.submit '交換する', class: 'btn btn-primary'

--- a/app/views/shop_items/purchase_item.turbo_stream.slim
+++ b/app/views/shop_items/purchase_item.turbo_stream.slim
@@ -1,0 +1,7 @@
+= turbo_stream.replace 'user_wallet_point' do
+  span#user_wallet_point.text-white = "#{current_user.user_wallet.reload.point}P"
+
+= turbo_stream.replace 'purchase_toast' do 
+  div.toast.fade.position-absolute.top-100.start-50.translate-middle-x.mt-2 id="purchase_toast" data-controller="toast" role="status" aria-live="polite" aria-atomic="true" data-bs-autohide="true" data-bs-delay="8000"
+    div.toast-body
+      = "#{@shop_item.item.name}を#{@count}個購入しました"

--- a/app/views/shop_items/show.html.slim
+++ b/app/views/shop_items/show.html.slim
@@ -1,0 +1,7 @@
+div.container
+  div.d-flex.justify-content-between.align-items-center.mb-3
+    = link_to '< 戻る', user_character_gift_items_path(@user_character), class: 'btn btn-secondary text-white rounded-pill px-4'
+
+  h1.text-white = @user_gift_item.gift_item.name
+  p.text-white = @user_gift_item.gift_item.description
+  p.text-white 所持数：#{@user_gift_item.quantity}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,12 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :shop_items, only: %i[index] do
+    member do
+      patch 'purchase_item'
+    end
+  end
+
   resources :contacts, only: [:new, :create] do
     collection do
       post 'confirm'

--- a/db/migrate/20260726040356_remove_quantity_from_shop_items.rb
+++ b/db/migrate/20260726040356_remove_quantity_from_shop_items.rb
@@ -1,0 +1,5 @@
+class RemoveQuantityFromShopItems < ActiveRecord::Migration[7.2]
+  def change
+    remove_column :shop_items, :quantity, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_07_18_093931) do
+ActiveRecord::Schema[7.2].define(version: 2026_07_26_040356) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -110,7 +110,6 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_18_093931) do
     t.datetime "updated_at", null: false
     t.string "item_type"
     t.bigint "item_id"
-    t.integer "quantity"
     t.float "price"
     t.index ["item_type", "item_id"], name: "index_shop_items_on_item"
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -132,6 +132,48 @@ TaskReward.find_or_create_by!(task_id: task.id) do |tr|
   tr.point = 100
 end
 
+# ギフトアイテム
+gift_item1 = GiftItem.find_or_create_by!(name: 'test_item') do |gi|
+  gi.friendship_point = 10
+  gi.image_path = 'https://placehold.jp/300x300.png?text=ギフト'
+  gi.description = 'テスト用のギフトアイテムです'
+end
+
+gift_item2 = GiftItem.find_or_create_by!(name: 'test_item2') do |gi|
+  gi.friendship_point = 20
+  gi.image_path = 'https://placehold.jp/300x300.png?text=ギフト2'
+  gi.description = 'テスト用のギフトアイテム2です'
+end
+
+gift_item3 = GiftItem.find_or_create_by!(name: 'test_item3') do |gi|
+  gi.friendship_point = 30
+  gi.image_path = 'https://placehold.jp/300x300.png?text=ギフト3'
+  gi.description = 'テスト用のギフトアイテム3です'
+end
+
+# 衣装アイテム
+outfit_item1 = OutfitItem.find_or_create_by!(name: 'testoutfit') do |oi|
+  oi.description = 'テスト用のアウトフィットです'
+  oi.image_path = 'https://placehold.jp/150x150.png'
+end
+
+# ショップ商品
+ShopItem.find_or_create_by!(item_type: 'GiftItem', item_id: gift_item1.id) do |si|
+  si.price = 100.0
+end
+
+ShopItem.find_or_create_by!(item_type: 'GiftItem', item_id: gift_item2.id) do |si|
+  si.price = 200.0
+end
+
+ShopItem.find_or_create_by!(item_type: 'GiftItem', item_id: gift_item3.id) do |si|
+  si.price = 300.0
+end
+
+ShopItem.find_or_create_by!(item_type: 'OutfitItem', item_id: outfit_item1.id) do |si|
+  si.price = 50.0
+end
+
 =begin
 #ユーザー指定
 user = User.find_or_create_by(uid: '76561198369759270')

--- a/spec/helpers/shop_items_helper_spec.rb
+++ b/spec/helpers/shop_items_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the ShopItemsHelper. For example:
+#
+# describe ShopItemsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe ShopItemsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/shop_items_spec.rb
+++ b/spec/requests/shop_items_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "ShopItems", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
## Summary
マイレージポイントを消費して、ギフトアイテム・衣装アイテムと交換できる「ポイント交換ページ」を追加。既存のギフト機能(present_gift)と同じUIパターン(モーダル確認+Turbo Stream更新)を踏襲。

## 主な変更
- `ShopItemsController#index`/`#purchase_item`、`resources :shop_items` ルーティングを追加
- `ShopItem.purchase_item_process`(交換処理本体)
  - GiftItem: 個数を指定して交換可能、`user_gift_items.quantity`を加算
  - OutfitItem: 1ユーザー1回まで(所持済みなら`user_wallet`の減算前にreturnし、ポイントを消費させない)
  - 未使用だった`shop_items.quantity`カラムは削除(在庫概念が不要だったため)
- ビュー: アイテム画像・説明のホバー切り替え(新規Stimulusコントローラー`shop-preview`)、所持済みOutfitItemのグレーアウト表示(`ShopItemsHelper#shop_item_owned?`)
- 交換確認モーダル→交換実行後、Turbo Streamで保持ポイント表示を更新し、「〇〇を△個購入しました」と一定時間で自動フェードアウトするトースト通知を表示(新規Stimulusコントローラー`toast`)
- `db/seeds.rb`にGiftItem/OutfitItem/ShopItemのテストデータを追加(価格・内容は仮データ、本番用の調整は別途対応予定)

## 今後の対応(別PR予定)
- ショップ商品の実際の内容・価格の整備
- ギフト/衣装アイテムのタブ分け表示