### PR TITLE
add:ゲーム価格取得中のローディングアニメーション追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem "cssbundling-rails"
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem "jbuilder"
 # Use Redis adapter to run Action Cable in production
-# gem "redis", ">= 4.0.1"
+gem "redis", ">= 4.0.1", "< 6"
 
 # Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
 # gem "kredis"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -343,7 +343,9 @@ GEM
       erb
       psych (>= 4.0.0)
       tsort
-    redis-client (0.30.0)
+    redis (5.4.1)
+      redis-client (>= 0.22.0)
+    redis-client (0.30.1)
       connection_pool
     regexp_parser (2.12.0)
     reline (0.6.3)
@@ -503,6 +505,7 @@ DEPENDENCIES
   puma (>= 5.0)
   rails (~> 7.2.3, >= 7.2.3.1)
   rails-i18n (~> 7.0.0)
+  redis (>= 4.0.1, < 6)
   rexml
   rspec-rails (~> 7.0.0)
   rubocop-rails-omakase
@@ -652,7 +655,8 @@ CHECKSUMS
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.3.1) sha256=8c9e89d09f66a26a01264e7e3480ec0607f0c497a861ef16063604b1b08eb19c
   rdoc (7.2.0) sha256=8650f76cd4009c3b54955eb5d7e3a075c60a57276766ebf36f9085e8c9f23192
-  redis-client (0.30.0) sha256=743f11ed42f0a41a0341554087b077479fec7e2d47a7c123fd90a12c0db5e477
+  redis (5.4.1) sha256=b5e675b57ad22b15c9bcc765d5ac26f60b675408af916d31527af9bd5a81faae
+  redis-client (0.30.1) sha256=5151bc5c7bbfe48623732cdae3b900d8a22dc691cc7cdfacfb351ac55116522d
   regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
   reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
   responders (3.2.0) sha256=89c2d6ac0ae16f6458a11524cae4a8efdceba1a3baea164d28ee9046bd3df55a

--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -72,3 +72,36 @@ body {
   border: 10px solid transparent;
   border-top-color: #131C27;
 }
+
+/* HTML: <div class="loader"></div> */
+.loader {
+  width: 30px;
+  aspect-ratio: 1;
+  display:inline-grid;
+  margin-left: 8px;
+  vertical-align: -5px;
+  -webkit-mask: conic-gradient(from 15deg,#0000,#000);
+  animation: l26 1s infinite steps(12);
+}
+.loader,
+.loader:before,
+.loader:after{
+  background:
+    radial-gradient(closest-side at 50% 12.5%,
+     #f4f4f4 96%,#0000) 50% 0/20% 80% repeat-y,
+    radial-gradient(closest-side at 12.5% 50%,
+     #f4f4f4 96%,#0000) 0 50%/80% 20% repeat-x;
+}
+.loader:before,
+.loader:after {
+  content: "";
+  grid-area: 1/1;
+  transform: rotate(30deg);
+}
+.loader:after {
+  transform: rotate(60deg);
+}
+
+@keyframes l26 {
+  100% {transform:rotate(1turn)}
+}

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,6 @@
 class UsersController < ApplicationController
   def show
+    @user = current_user
     @page = 'users_show'
     @total_price = UserGameLibrary.total_price(current_user)
     @character_text = CharacterTextService.new.get_character_text(current_user.user_characters.first, @page, @total_price)

--- a/app/jobs/update_game_price_job.rb
+++ b/app/jobs/update_game_price_job.rb
@@ -1,13 +1,30 @@
 class UpdateGamePriceJob < ApplicationJob
   queue_as :default
 
-  def perform(steam_app_id)
+  def perform(user_id, steam_app_id)
     game = Game.find_by(steam_app_id: steam_app_id)
     return unless game
 
     prices = SteamApiService.new.get_game_price_and_genre(steam_app_id)
-    return unless prices
 
-    game.update(price: prices[:price])
+    user = User.find_by(id: user_id)
+
+    if prices
+      game.update(price: prices[:price] || 0)
+      unless UserGameLibrary.any_library_game_prices_nil?(user)
+        Turbo::StreamsChannel.broadcast_replace_to(
+          user, 
+          target: "total_price",
+          partial: "user_game_libraries/total_price",
+          locals: { total_price: UserGameLibrary.total_price(user), user: user }
+        )
+      end
+    else
+      Turbo::StreamsChannel.broadcast_replace_to(
+        user,
+        target: "total_price",
+        html: '<span id="total_price"><span class="fs-3">価格の取得に失敗しました。ページの再読み込みをしてください。</span></span>'
+      )
+    end
   end
 end

--- a/app/models/user_game_library.rb
+++ b/app/models/user_game_library.rb
@@ -38,7 +38,7 @@ class UserGameLibrary < ApplicationRecord
       end
       library.save!
     end
-    UpdateGamePriceJob.perform_later(game.steam_app_id) if game.price.nil?
+    UpdateGamePriceJob.perform_later(user.id, game.steam_app_id) if game.price.nil?
     UpdateGameGenreJob.perform_later(game.steam_app_id) if game.game_genres.empty?
   end
 
@@ -75,5 +75,9 @@ class UserGameLibrary < ApplicationRecord
 
   def self.total_playtime_count(user)
     user.user_game_libraries.sum(:minutes_played)
+  end
+
+  def self.any_library_game_prices_nil?(user)
+    user.user_game_libraries.unplayed.joins(:game).where(games: { price: nil }).exists?
   end
 end

--- a/app/services/steam_api_service.rb
+++ b/app/services/steam_api_service.rb
@@ -11,7 +11,7 @@ class SteamApiService
     })
 
     data = response.parsed_response.dig(steam_app_id.to_s, 'data')
-    return nil unless data.is_a?(Hash)
+    return {price: nil, genres: nil} unless data.is_a?(Hash)
     {price: data.dig('price_overview', 'final')&./(100.0), genres: data.dig('genres')}
   end
 end

--- a/app/views/statistics/show.html.slim
+++ b/app/views/statistics/show.html.slim
@@ -1,8 +1,10 @@
+= turbo_stream_from current_user
+
 div.card.text-white.w-50.border-0.mx-auto.mt-5
   div.card-header.card-header-color.pb-0
     p.p-1 #{@user.name}
   div.card-body.card-body-color.d-flex
-    p.me-4 積みゲー総額: #{number_to_currency(@total_price, precision: 0, unit: '¥')}
+    p.me-4 積みゲー総額: #{render "user_game_libraries/total_price", total_price: @total_price, user: @user}
     p.me-4 積みゲー本数: #{@unplayed_games.count}
     p.me-4 全体消化率: #{@cleared_game_count_rate.round(2)}%
 

--- a/app/views/user_game_libraries/_total_price.html.slim
+++ b/app/views/user_game_libraries/_total_price.html.slim
@@ -1,0 +1,6 @@
+span#total_price
+    - if UserGameLibrary.any_library_game_prices_nil?(user)
+        span.fs-3 計算中…
+        span.loader
+    - else
+        = number_to_currency(total_price, precision: 0, unit: '¥')

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -1,6 +1,8 @@
+= turbo_stream_from current_user
+
 p.text-center.fs-1.mt-5.mb-0 あなたの積みゲー総額は
 div.text-center.price-display.fw-bold.mt-0
-    = number_to_currency(@total_price, precision: 0, unit: '¥')
+    = render "user_game_libraries/total_price", total_price: @total_price, user: @user
 
 div.character-fixed
     div.speech-bubble.mb-3.d-flex.align-items-center

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,5 +1,6 @@
 development:
-  adapter: async
+  adapter: redis
+  url: <%= ENV.fetch("REDIS_URL") { "redis://redis:6379/1" } %>
 
 test:
   adapter: test


### PR DESCRIPTION
## 概要

積みゲー総額(トップページ・統計ページ)の表示について、`UpdateGamePriceJob`(Steamの価格取得の非同期ジョブ)が未完了のゲームがあると、`SUM()`がNULLを無視するため実際より少ない金額がそのまま表示されてしまう問題があった。ActionCable(Turbo Streams)を使い、価格取得が完了するまでローディング表示を出し、完了次第リアルタイムで金額表示・キャラクターのセリフ/表情に切り替わるようにした。

## 主な変更点

- `UserGameLibrary.any_library_game_prices_nil?(user)`: あるユーザーの積みゲーの中に価格未取得のゲームが残っているかを判定するクラスメソッドを追加
- `UpdateGamePriceJob`:
  - `user_id`を引数に追加し、価格取得完了後にそのユーザーの残り件数を再判定してブロードキャストするように変更
  - 取得成功時は`Turbo::StreamsChannel.broadcast_replace_to`で金額表示・キャラクターのセリフ/表情に、取得失敗時はエラーメッセージに切り替え
  - 無料ゲーム・ストアページが存在しないゲーム(`price_overview`が取得できないケース)は`price: 0`として保存し、恒久的にローディングが終わらない状態を回避
- `SteamApiService`: APIレスポンスが`Hash`でない場合(ストアページなし等)にクラッシュせず`{price: nil, genres: nil}`を返すよう修正
- `app/views/user_game_libraries/_total_price.html.slim`: ローディング/金額表示を出し分ける共有パーシャルを新規追加(トップページ・統計ページ両方から使用)
- `app/views/user_characters/_character_display.html.slim`: キャラクターの吹き出し・画像表示を共有パーシャルとして切り出し
- `users_controller.rb`: 価格取得中は`CharacterTextCondition`の`users_show_loading`ページ用の専用セリフ・表情(「少しドキドキしますね…！」/happy)を表示するよう変更
- `db/seeds.rb`: 読み込み中用の`CharacterTextCondition`・`CharacterText`を追加
- `users/show.html.slim`, `statistics/show.html.slim`: `turbo_stream_from(current_user)`を追加し、上記パーシャルを使うよう変更
- `config/cable.yml`: development環境のAction Cableアダプタを`async`から`redis`に変更(Web/Sidekiqが別プロセスのため)
- `Gemfile`: `redis` gemを追加(`< 6`でActionCableの依存バージョンと衝突しないよう制約)
- ローディング中はCSSスピナーアニメーションを表示