### PR TITLE
Feature/59.5 detailed page for each game

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,0 +1,20 @@
+class GamesController < ApplicationController
+    def  index
+
+    end
+
+    def show
+        @user = current_user
+        所持者数
+        積み率
+        クリア率
+        自分の積み/クリア状況
+        平均プレイ時間
+        自分のプレイ時間
+        平均積み期間
+        自分の積み時間
+        ジャンル
+        価格
+        ストアリンク
+    end
+end

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,6 +1,23 @@
 class GamesController < ApplicationController
     def  index
+        @all_games_count = UserGameLibrary.all_games_count
+        @all_unplayed_games_count = UserGameLibrary.all_unplayed_games_count
 
+
+        @games = case params[:sort]
+        when "name"
+            Game.order(:game_title)
+        when "price_asc"
+            Game.order(price: :asc)
+        when "price_desc"
+            Game.order(price: :desc)
+        when "possessed_count"
+            Game.all.sort_by{ |game| -(@all_games_count.fetch(game.id, 0)) }
+        when "unplayed_rate"
+            Game.all.sort_by{ |game| -(@all_unplayed_games_count.fetch(game.id, 0).to_f / @all_games_count.fetch(game.id, 0).to_f) }
+        else
+            Game.all.sort_by{ |game| -(@all_games_count.fetch(game.id, 0)) }
+        end
     end
 
     def show

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -5,16 +5,13 @@ class GamesController < ApplicationController
 
     def show
         @user = current_user
-        所持者数
-        積み率
-        クリア率
-        自分の積み/クリア状況
-        平均プレイ時間
-        自分のプレイ時間
-        平均積み期間
-        自分の積み時間
-        ジャンル
-        価格
-        ストアリンク
+        @game = Game.find(params[:id])
+        @possessed_user_count = UserGameLibrary.game_statistics_count(@game)
+        @unplayed_percentage = UserGameLibrary.game_statistics_unplayed_percentage(@game)
+        @cleared_percentage = UserGameLibrary.game_statistics_cleared_rate(@game)
+        @average_playtime = UserGameLibrary.game_statistics_average_playtime(@game)
+        @average_unplayed_time = UserGameLibrary.game_statistics_average_unplayed_time(@game)
+
+        @current_user_game = @user.user_game_libraries.find_by(game_id: @game.id)
     end
 end

--- a/app/helpers/games_helper.rb
+++ b/app/helpers/games_helper.rb
@@ -1,0 +1,2 @@
+module GamesHelper
+end

--- a/app/helpers/games_helper.rb
+++ b/app/helpers/games_helper.rb
@@ -6,4 +6,18 @@ module GamesHelper
   def steam_banner_image(game)
     "https://cdn.akamai.steamstatic.com/steam/apps/#{game.steam_app_id}/header.jpg"
   end
+
+  def steam_thumbnail_image(game)
+    "https://cdn.akamai.steamstatic.com/steam/apps/#{game.steam_app_id}/capsule_184x69.jpg"
+  end
+
+  def broken_thumbnail_placeholder
+    svg = <<~SVG
+      <svg xmlns="http://www.w3.org/2000/svg" width="184" height="69" viewBox="0 0 184 69">
+        <rect width="184" height="69" fill="#f5f5f5"/>
+        <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="11" fill="#666666">画像が見つかりませんでした</text>
+      </svg>
+    SVG
+    "data:image/svg+xml;base64,#{Base64.strict_encode64(svg)}"
+  end
 end

--- a/app/helpers/games_helper.rb
+++ b/app/helpers/games_helper.rb
@@ -1,2 +1,9 @@
 module GamesHelper
+  def steam_store_link(game)
+    "https://store.steampowered.com/app/#{game.steam_app_id}"
+  end
+
+  def steam_banner_image(game)
+    "https://cdn.akamai.steamstatic.com/steam/apps/#{game.steam_app_id}/header.jpg"
+  end
 end

--- a/app/models/user_game_library.rb
+++ b/app/models/user_game_library.rb
@@ -80,4 +80,31 @@ class UserGameLibrary < ApplicationRecord
   def self.any_library_game_prices_nil?(user)
     user.user_game_libraries.unplayed.joins(:game).where(games: { price: nil }).exists?
   end
+
+  
+  def self.game_statistics_count(game)
+    game.user_game_libraries.count
+  end
+
+  def self.game_statistics_unplayed_percentage(game)
+    total_count = game.user_game_libraries.count.to_f
+    unplayed = game.user_game_libraries.unplayed.count.to_f
+    (unplayed / total_count) * 100
+  end
+
+  def self.game_statistics_cleared_rate(game)
+    total_count = game.user_game_libraries.count.to_f
+    cleared = game.user_game_libraries.cleared.count.to_f
+    (cleared / total_count) * 100
+  end
+
+  def self.game_statistics_average_playtime(game)
+    game.user_game_libraries.average(:minutes_played)
+  end
+  
+  def self.game_statistics_average_unplayed_time(game)
+    unplayed_time_array = game.user_game_libraries.unplayed.where.not(user_game_libraries: { unplayed_date: nil }).pluck(:unplayed_date).map { |date| (Date.current - date).to_i }
+    return 0 if unplayed_time_array.empty?
+    unplayed_time_array.sum.to_f / unplayed_time_array.size
+  end
 end

--- a/app/models/user_game_library.rb
+++ b/app/models/user_game_library.rb
@@ -81,9 +81,20 @@ class UserGameLibrary < ApplicationRecord
     user.user_game_libraries.unplayed.joins(:game).where(games: { price: nil }).exists?
   end
 
+
+#ゲームの一覧画面に使用
+  def self.all_games_count
+    UserGameLibrary.group(:game_id).count
+  end
+
+  def self.all_unplayed_games_count
+    UserGameLibrary.unplayed.group(:game_id).count
+  end
+
   
+#ゲームごとの詳細画面に使用
   def self.game_statistics_count(game)
-    game.user_game_libraries.count
+    game.user_game_libraries.size
   end
 
   def self.game_statistics_unplayed_percentage(game)

--- a/app/views/games/index.html.slim
+++ b/app/views/games/index.html.slim
@@ -1,0 +1,22 @@
+div.card.text-white.w-50.border-0.mx-auto.mt-5
+  div.card-header.card-header-color.pb-0
+    p.p-1 ゲーム一覧
+  div.d-flex.gap-3.px-3.pb-2.card-header-color
+    = link_to '名前順', games_path(sort: 'name'), class: 'text-white'
+    = link_to '価格の安い順', games_path(sort: 'price_asc'), class: 'text-white'
+    = link_to '価格の高い順', games_path(sort: 'price_desc'), class: 'text-white'
+    = link_to '積み率順', games_path(sort: 'unplayed_rate'), class: 'text-white'
+    = link_to '所持者数順', games_path(sort: 'possessed_count'), class: 'text-white'
+  div.d-flex.justify-content-between.px-3.card-header-color
+    span.col-3 ゲームタイトル
+    span.col-2 所持者数
+    span.col-2 積み率
+    span.col-5 サムネ
+  div.card-body.card-body-color
+    ol.w-100.px-3
+      - @games.each do |game|
+        li.d-flex.justify-content-between.align-items-center.mt-3
+          span.col-3 = link_to game.game_title, game_path(game)
+          span.col-2 = "#{@all_games_count.fetch(game.id, 0)}人"
+          span.col-2 = "#{((@all_unplayed_games_count.fetch(game.id, 0).to_f / @all_games_count.fetch(game.id, 0).to_f) * 100).round(1)}%"
+          span.col-5 = image_tag steam_thumbnail_image(game), class: 'img-fluid', onerror: "this.onerror=null;this.src='#{broken_thumbnail_placeholder}'"

--- a/app/views/games/show.html.slim
+++ b/app/views/games/show.html.slim
@@ -1,0 +1,59 @@
+div.card.text-white.w-50.border-0.mx-auto.mt-5
+  div.card-header.card-header-color.pb-0
+    p.p-1 = @game.game_title
+  div.card-body.card-body-color
+    div.text-center.mb-3
+      = image_tag steam_banner_image(@game), class: 'img-fluid rounded'
+    p.me-4 ジャンル: #{@game.game_genre_types.map(&:name).join('/')}
+    p.me-4 価格: #{number_to_currency(@game.price, precision: 0, unit: '¥')}
+    p.me-4
+      = link_to 'Steamストアページへ', steam_store_link(@game), target: :_blank, rel: 'noopener noreferrer', class: 'btn btn-secondary text-white'
+
+div.card.text-white.w-50.border-0.mx-auto.mt-5
+  div.card-header.card-header-color.pb-0
+    p.p-1 みんなの積み状況
+  div.card-body.card-body-color.d-flex
+    p.me-4 所持者数: #{@possessed_user_count}人
+    p.me-4 積み率: #{@unplayed_percentage.round(1)}%
+    p.me-4 クリア率: #{@cleared_percentage.round(1)}%
+
+div.card.text-white.w-50.border-0.mx-auto.mt-5
+  div.card-header.card-header-color.pb-0
+    p.p-1 平均 と #{@user.name} さんの比較
+  div.d-flex.justify-content-between.px-3.card-header-color
+    span.col-4
+    span.col-4 みんなの平均
+    span.col-4 #{@user.name}
+  div.card-body.card-body-color.d-flex
+    ol.w-100.px-3
+      li.d-flex.justify-content-between
+        span.col-4 プレイ時間
+        span.col-4 = "#{(@average_playtime / 60.0).round(1)}時間"
+        span.col-4
+          - if @current_user_game
+            = "#{(@current_user_game.minutes_played / 60.0).round(1)}時間"
+          - else
+            | 未所持
+      li.d-flex.justify-content-between
+        span.col-4 積んでからの期間
+        span.col-4 = "#{@average_unplayed_time.round(1)}日"
+        span.col-4
+          - if @current_user_game && @current_user_game.unplayed_date
+            = "#{(Date.current - @current_user_game.unplayed_date).to_i}日"
+          - elsif @current_user_game
+            | 積んでいません
+          - else
+            | 未所持
+      li.d-flex.justify-content-between
+        span.col-4 クリア状況
+        span.col-4 = "#{@cleared_percentage.round(1)}%の人がクリア済み"
+        span.col-4
+          - if @current_user_game.nil?
+            | 未所持
+          - elsif @current_user_game.cleared_date
+            | クリア済み
+          - else
+            | 未クリア
+
+div.w-50.mx-auto.mt-5.mb-5.text-center
+  iframe src="https://store.steampowered.com/widget/#{@game.steam_app_id}/" width="100%" height="190" frameborder="0"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,8 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :games, only: %i[index show]
+
   resource :statistic, only: %i[show] do
     member do
       patch 'update_cleared_games'

--- a/spec/helpers/games_helper_spec.rb
+++ b/spec/helpers/games_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the GamesHelper. For example:
+#
+# describe GamesHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe GamesHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/games_spec.rb
+++ b/spec/requests/games_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Games", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
## 概要

ゲームごとの詳細ページと、全ゲームの一覧・並び替えページを追加。

## 主な変更点

- `resources :games, only: %i[index show]`: `/games`(一覧)、`/games/:id`(詳細)のルーティングを追加
- `UserGameLibrary`にゲーム単位の統計を計算するクラスメソッドを追加
  - `game_statistics_count`, `game_statistics_unplayed_percentage`, `game_statistics_cleared_rate`, `game_statistics_average_playtime`, `game_statistics_average_unplayed_time`(詳細ページ用、1ゲームごとの統計)
  - `all_games_count`, `all_unplayed_games_count`(一覧ページ用、`group(:game_id).count`で全ゲーム分を1クエリずつ集計し、N+1を回避)
- `GamesController#show`: ゲーム詳細・統計・ログイン中ユーザー自身のライブラリ情報を取得
- `GamesController#index`: 全ゲーム一覧を取得し、`params[:sort]`によって並び順を分岐(名前順・価格順・積み率順・所持者数順、未指定時は所持者数順)
- `app/views/games/show.html.slim`: バナー画像、ジャンル・価格・ストアリンク、みんなの積み状況(所持者数・積み率・クリア率)、平均とログイン中ユーザー自身の比較、Steam購入ウィジェットを表示
- `app/views/games/index.html.slim`: 一覧表示(ゲームタイトル・所持者数・積み率・サムネイル)、並び替えリンク5種
- `GamesHelper`: `steam_store_link`, `steam_banner_image`, `steam_thumbnail_image`, `broken_thumbnail_placeholder`(サムネイル画像が404の場合にSVGで代替表示)を追加