### PR TITLE
fix:価格取得処理にゲームの日本語名取得を追加

### DIFF
--- a/app/jobs/update_game_price_job.rb
+++ b/app/jobs/update_game_price_job.rb
@@ -10,7 +10,7 @@ class UpdateGamePriceJob < ApplicationJob
     user = User.find_by(id: user_id)
 
     if prices
-      game.update(price: prices[:price] || 0)
+      game.update(price: prices[:price] || 0, game_title: prices[:name].presence || game.game_title)
       unless UserGameLibrary.any_library_game_prices_nil?(user)
         Turbo::StreamsChannel.broadcast_replace_to(
           user,

--- a/app/models/user_game_library.rb
+++ b/app/models/user_game_library.rb
@@ -40,6 +40,9 @@ class UserGameLibrary < ApplicationRecord
     end
     UpdateGamePriceJob.perform_later(user.id, game.steam_app_id) if game.price.nil?
     UpdateGameGenreJob.perform_later(game.steam_app_id) if game.game_genres.empty?
+  rescue => e
+    Rails.logger.error(e.message)
+    return
   end
 
   def self.cost_performance_ranking(user)

--- a/app/services/steam_api_service.rb
+++ b/app/services/steam_api_service.rb
@@ -7,11 +7,11 @@ class SteamApiService
       appids: steam_app_id,
       cc: 'jp',
       l: 'japanese',
-      filters: 'price_overview,genres'
+      filters: 'basic,price_overview,genres'
     })
 
     data = response.parsed_response.dig(steam_app_id.to_s, 'data')
-    return {price: nil, genres: nil} unless data.is_a?(Hash)
-    {price: data.dig('price_overview', 'final')&./(100.0), genres: data.dig('genres')}
+    return {price: nil, genres: nil, name: nil} unless data.is_a?(Hash)
+    {price: data.dig('price_overview', 'final')&./(100.0), genres: data.dig('genres'), name: data['name']}
   end
 end


### PR DESCRIPTION
## 概要
ゲームライブラリ同期時、`game_title`がSteamの`GetOwnedGames` APIから取得した英語名のまま保存され、日本語化されていなかった。既存の価格/ジャンル取得(`SteamApiService`)が`l: 'japanese'`を指定していたのに対し、こちらは日本語名も取得可能だったため、価格取得と同じタイミングで日本語名を取得・上書きするようにした。

## 変更内容
- `SteamApiService#get_game_price_and_genre`: `filters`に`basic`を追加し、日本語名(`name`)も取得するように変更
- `UpdateGamePriceJob`: 価格更新と同時に、取得できた日本語名で`game_title`を上書き(取得失敗時は既存の値を保持)
- `UserGameLibrary.sync_game_playtime_and_price`: ゲーム作成/ライブラリ保存時に例外(例: 日本語名も英語名も取得できず`game_title`のバリデーションに失敗するケース)が発生した場合、そのゲーム1件をスキップして処理を継続するよう`rescue`を追加(同期処理全体が1件のエラーで止まらないようにするため)