### PR TITLE
Feature/59 search for game index page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,8 @@ gem 'ruby-vips'
 
 gem 'kaminari'
 
+gem 'ransack'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,8 @@ gem 'meta-tags'
 
 gem 'ruby-vips'
 
+gem 'kaminari'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -351,6 +351,10 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.3.1)
+    ransack (4.4.1)
+      activerecord (>= 7.2)
+      activesupport (>= 7.2)
+      i18n
     rdoc (7.2.0)
       erb
       psych (>= 4.0.0)
@@ -518,6 +522,7 @@ DEPENDENCIES
   puma (>= 5.0)
   rails (~> 7.2.3, >= 7.2.3.1)
   rails-i18n (~> 7.0.0)
+  ransack
   redis (>= 4.0.1, < 6)
   rexml
   rspec-rails (~> 7.0.0)
@@ -671,6 +676,7 @@ CHECKSUMS
   railties (7.2.3.1) sha256=aea3393ee10243ceedcbeccb45458a0d58b524b6d21bf32eff8b93853baae15a
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.3.1) sha256=8c9e89d09f66a26a01264e7e3480ec0607f0c497a861ef16063604b1b08eb19c
+  ransack (4.4.1) sha256=6aeaac36fc19088570e10da1044e6cfd88c740e20f871b84566fd30e32b7a63d
   rdoc (7.2.0) sha256=8650f76cd4009c3b54955eb5d7e3a075c60a57276766ebf36f9085e8c9f23192
   redis (5.4.1) sha256=b5e675b57ad22b15c9bcc765d5ac26f60b675408af916d31527af9bd5a81faae
   redis-client (0.30.1) sha256=5151bc5c7bbfe48623732cdae3b900d8a22dc691cc7cdfacfb351ac55116522d

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,6 +178,18 @@ GEM
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
     json (2.19.3)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     language_server-protocol (3.17.0.5)
     launchy (3.1.1)
       addressable (~> 2.8)
@@ -496,6 +508,7 @@ DEPENDENCIES
   httparty
   jbuilder
   jsbundling-rails
+  kaminari
   letter_opener_web
   meta-tags
   omniauth-rails_csrf_protection
@@ -584,6 +597,10 @@ CHECKSUMS
   jbuilder (2.14.1) sha256=4eb26376ff60ef100cb4fd6fd7533cd271f9998327e86adf20fd8c0e69fabb42
   jsbundling-rails (1.3.1) sha256=0fa03f6d051c694cbf55a022d8be53399879f2c4cf38b2968f86379c62b1c2ca
   json (2.19.3) sha256=289b0bb53052a1fa8c34ab33cc750b659ba14a5c45f3fcf4b18762dc67c78646
+  kaminari (1.2.2) sha256=c4076ff9adccc6109408333f87b5c4abbda5e39dc464bd4c66d06d9f73442a3e
+  kaminari-actionview (1.2.2) sha256=1330f6fc8b59a4a4ef6a549ff8a224797289ebf7a3a503e8c1652535287cc909
+  kaminari-activerecord (1.2.2) sha256=0dd3a67bab356a356f36b3b7236bcb81cef313095365befe8e98057dd2472430
+  kaminari-core (1.2.2) sha256=3bd26fec7370645af40ca73b9426a448d09b8a8ba7afa9ba3c3e0d39cdbb83ff
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   launchy (3.1.1) sha256=72b847b5cc961589dde2c395af0108c86ff0119f42d4648d25b5440ebb10059e
   letter_opener (1.10.0) sha256=2ff33f2e3b5c3c26d1959be54b395c086ca6d44826e8bf41a14ff96fdf1bdbb2

--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -25,6 +25,31 @@ body {
     background-color: #325C80;
 }
 
+.search-suggestion-item {
+    transition: background-color 0.15s ease-in-out;
+
+    &:hover {
+        background-color: rgba(255, 255, 255, 0.1);
+    }
+}
+
+.search-input {
+    background-color: #2A3F5A;
+    color: #fff;
+    border: 1px solid #67707B;
+
+    &::placeholder {
+        color: #ccc;
+    }
+
+    &:focus {
+        background-color: #2A3F5A;
+        color: #fff;
+        box-shadow: none;
+        border-color: #325C80;
+    }
+}
+
 nav.pagination {
     background-color: transparent;
     display: flex;

--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -25,6 +25,42 @@ body {
     background-color: #325C80;
 }
 
+nav.pagination {
+    background-color: transparent;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 1rem 0;
+
+    span.gap {
+        color: #ccc;
+        padding: 0 0.25rem;
+    }
+
+    span a {
+        display: inline-block;
+        padding: 0.35rem 0.75rem;
+        border-radius: 0.375rem;
+        background-color: #67707B;
+        color: #fff;
+        text-decoration: none;
+
+        &:hover {
+            background-color: #7d8791;
+        }
+    }
+
+    span.page.current {
+        display: inline-block;
+        padding: 0.35rem 0.75rem;
+        border-radius: 0.375rem;
+        background-color: #325C80;
+        color: #fff;
+        font-weight: bold;
+    }
+}
+
 .task-row-claimable {
     background-color: #326E4F;
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@ class ApplicationController < ActionController::Base
   allow_browser versions: :modern
 
   before_action :authenticate_user!, unless: :devise_controller?
+  before_action :set_search
 
   def after_sign_in_path_for(resource)
     loading_user_game_libraries_path
@@ -11,4 +12,9 @@ class ApplicationController < ActionController::Base
   def after_sign_out_path_for(resource_or_scope)
     root_path
   end
+
+  def set_search
+    @q = Game.ransack(params[:q])
+  end
+
 end

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -3,20 +3,19 @@ class GamesController < ApplicationController
         @all_games_count = UserGameLibrary.all_games_count
         @all_unplayed_games_count = UserGameLibrary.all_unplayed_games_count
 
-
         @games = case params[:sort]
         when "name"
-            Game.order(:game_title)
+            Game.order(:game_title).page(params[:page])
         when "price_asc"
-            Game.order(price: :asc)
+            Game.order(price: :asc).page(params[:page])
         when "price_desc"
-            Game.order(price: :desc)
+            Game.order(price: :desc).page(params[:page])
         when "possessed_count"
-            Game.all.sort_by{ |game| -(@all_games_count.fetch(game.id, 0)) }
+            Kaminari.paginate_array(Game.all.sort_by{ |game| -(@all_games_count.fetch(game.id, 0)) }).page(params[:page])
         when "unplayed_rate"
-            Game.all.sort_by{ |game| -(@all_unplayed_games_count.fetch(game.id, 0).to_f / @all_games_count.fetch(game.id, 0).to_f) }
+            Kaminari.paginate_array(Game.all.sort_by{ |game| -(@all_unplayed_games_count.fetch(game.id, 0).to_f / @all_games_count.fetch(game.id, 0).to_f) }).page(params[:page])
         else
-            Game.all.sort_by{ |game| -(@all_games_count.fetch(game.id, 0)) }
+            Kaminari.paginate_array(Game.all.sort_by{ |game| -(@all_games_count.fetch(game.id, 0)) }).page(params[:page])
         end
     end
 

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,21 +1,22 @@
 class GamesController < ApplicationController
     def  index
+        @q = Game.ransack(params[:q])
         @all_games_count = UserGameLibrary.all_games_count
         @all_unplayed_games_count = UserGameLibrary.all_unplayed_games_count
 
         @games = case params[:sort]
         when "name"
-            Game.order(:game_title).page(params[:page])
+            @q.result(distinct: true).order(:game_title).page(params[:page])
         when "price_asc"
-            Game.order(price: :asc).page(params[:page])
+            @q.result(distinct: true).order(price: :asc).page(params[:page])
         when "price_desc"
-            Game.order(price: :desc).page(params[:page])
+            @q.result(distinct: true).order(price: :desc).page(params[:page])
         when "possessed_count"
-            Kaminari.paginate_array(Game.all.sort_by{ |game| -(@all_games_count.fetch(game.id, 0)) }).page(params[:page])
+            Kaminari.paginate_array(@q.result(distinct: true).all.sort_by{ |game| -(@all_games_count.fetch(game.id, 0)) }).page(params[:page])
         when "unplayed_rate"
-            Kaminari.paginate_array(Game.all.sort_by{ |game| -(@all_unplayed_games_count.fetch(game.id, 0).to_f / @all_games_count.fetch(game.id, 0).to_f) }).page(params[:page])
+            Kaminari.paginate_array(@q.result(distinct: true).all.sort_by{ |game| -(@all_unplayed_games_count.fetch(game.id, 0).to_f / @all_games_count.fetch(game.id, 0).to_f) }).page(params[:page])
         else
-            Kaminari.paginate_array(Game.all.sort_by{ |game| -(@all_games_count.fetch(game.id, 0)) }).page(params[:page])
+            Kaminari.paginate_array(@q.result(distinct: true).all.sort_by{ |game| -(@all_games_count.fetch(game.id, 0)) }).page(params[:page])
         end
     end
 

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,6 +1,7 @@
 class GamesController < ApplicationController
+    SEARCH_SUGGESTION_LIMITS = 5
+
     def  index
-        @q = Game.ransack(params[:q])
         @all_games_count = UserGameLibrary.all_games_count
         @all_unplayed_games_count = UserGameLibrary.all_unplayed_games_count
 
@@ -18,6 +19,12 @@ class GamesController < ApplicationController
         else
             Kaminari.paginate_array(@q.result(distinct: true).all.sort_by{ |game| -(@all_games_count.fetch(game.id, 0)) }).page(params[:page])
         end
+    end
+
+    def search_suggestions
+        @suggestions = Game.ransack(game_title_cont: params[:q]).result.limit(SEARCH_SUGGESTION_LIMITS)
+        @all_games_count = UserGameLibrary.all_games_count
+        @all_unplayed_games_count = UserGameLibrary.all_unplayed_games_count
     end
 
     def show

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -10,11 +10,14 @@ application.register("gift-modal", GiftModalController)
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
 
-import TooltipController from "./tooltip_controller"
-application.register("tooltip", TooltipController)
+import SearchController from "./search_controller"
+application.register("search", SearchController)
 
 import ShopPreviewController from "./shop_preview_controller"
 application.register("shop-preview", ShopPreviewController)
 
 import ToastController from "./toast_controller"
 application.register("toast", ToastController)
+
+import TooltipController from "./tooltip_controller"
+application.register("tooltip", TooltipController)

--- a/app/javascript/controllers/search_controller.js
+++ b/app/javascript/controllers/search_controller.js
@@ -1,0 +1,36 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["frame"]
+
+  connect() {
+    this.closeOnOutsideClick = this.closeOnOutsideClick.bind(this)
+    document.addEventListener("click", this.closeOnOutsideClick)
+  }
+
+  disconnect() {
+    document.removeEventListener("click", this.closeOnOutsideClick)
+  }
+
+  search(event) {
+    clearTimeout(this.timeout)
+
+    const value = event.target.value.trim()
+    if (value === "") {
+      this.frameTarget.innerHTML = ""
+      this.frameTarget.removeAttribute("src")
+      return
+    }
+
+    this.timeout = setTimeout(() => {
+        this.frameTarget.src = `/games/search_suggestions?q=${encodeURIComponent(value)}`
+    }, 300)
+  }
+
+  closeOnOutsideClick(event) {
+    if (!this.element.contains(event.target)) {
+      this.frameTarget.innerHTML = ""
+      this.frameTarget.removeAttribute("src")
+    }
+  }
+}

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -15,4 +15,12 @@ class Game < ApplicationRecord
     end
     game
   end
+
+  def self.ransackable_attributes(auth_object = nil)
+    ["game_title"]
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    []
+  end
 end

--- a/app/views/games/index.html.slim
+++ b/app/views/games/index.html.slim
@@ -20,3 +20,4 @@ div.card.text-white.w-50.border-0.mx-auto.mt-5
           span.col-2 = "#{@all_games_count.fetch(game.id, 0)}人"
           span.col-2 = "#{((@all_unplayed_games_count.fetch(game.id, 0).to_f / @all_games_count.fetch(game.id, 0).to_f) * 100).round(1)}%"
           span.col-5 = image_tag steam_thumbnail_image(game), class: 'img-fluid', onerror: "this.onerror=null;this.src='#{broken_thumbnail_placeholder}'"
+    = paginate @games

--- a/app/views/games/search_suggestions.html.slim
+++ b/app/views/games/search_suggestions.html.slim
@@ -1,0 +1,10 @@
+= turbo_frame_tag "search_suggestions" do
+  - if @suggestions.present?
+    div.bg-dark.rounded.border-top.border-secondary
+      - @suggestions.each do |game|
+        - unplayed_rate = (@all_unplayed_games_count.fetch(game.id, 0).to_f / @all_games_count.fetch(game.id, 0).to_f * 100).round(1)
+        = link_to game_path(game), data: { turbo_frame: "_top" }, class: "search-suggestion-item d-flex align-items-center text-white text-decoration-none p-2 border-bottom border-secondary" do
+          = image_tag steam_thumbnail_image(game), class: 'me-3', style: 'width: 92px; height: 35px; object-fit: cover;', onerror: "this.onerror=null;this.src='#{broken_thumbnail_placeholder}'"
+          div
+            div = game.game_title
+            div.small = "積み率 #{unplayed_rate}%"

--- a/app/views/layouts/_header.slim
+++ b/app/views/layouts/_header.slim
@@ -26,3 +26,8 @@ nav.navbar.navbar-expand-lg.ps-3.fixed-top
           li
             = link_to 'ログアウト', destroy_user_session_path, class: 'dropdown-item', data: {turbo_method: :delete}
             = link_to 'アカウント削除', user_path , class: 'dropdown-item', data: {turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }
+
+      div.pe-3
+        = search_form_for  @q do |f|
+          = f.search_field :game_title_cont
+          = f.submit "検索"

--- a/app/views/layouts/_header.slim
+++ b/app/views/layouts/_header.slim
@@ -27,7 +27,8 @@ nav.navbar.navbar-expand-lg.ps-3.fixed-top
             = link_to 'ログアウト', destroy_user_session_path, class: 'dropdown-item', data: {turbo_method: :delete}
             = link_to 'アカウント削除', user_path , class: 'dropdown-item', data: {turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }
 
-      div.pe-3
-        = search_form_for  @q do |f|
-          = f.search_field :game_title_cont
-          = f.submit "検索"
+      div.position-relative data-controller="search"
+        = search_form_for @q, html: { class: "d-flex align-items-center" } do |f|
+          = f.search_field :game_title_cont, data: { action: "input->search#search focus->search#search" }, class: "search-input rounded me-2", placeholder: "ゲームを検索", autocomplete: "off"
+          = f.submit "検索", class: "btn btn-color text-white"
+        = turbo_frame_tag "search_suggestions", data: { search_target: "frame" }, class: "position-absolute top-100 end-0 mt-1", style: "z-index: 1050; width: 350px;"

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,5 +24,7 @@ module Myapp
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
     config.active_job.queue_adapter = :sidekiq
+
+    config.i18n.default_locale = :ja
   end
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,8 @@
+ja:
+  views:
+    pagination:
+      first: <i class="fas fa-angle-double-left"></i>
+      last: <i class="fas fa-angle-double-right"></i>
+      previous: <i class="fas fa-angle-left"></i>
+      next: <i class="fas fa-angle-right"></i>
+      truncate: "&hellip;"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,7 +26,11 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :games, only: %i[index show]
+  resources :games, only: %i[index show] do
+    collection do
+      get :search_suggestions
+    end
+  end
 
   resource :statistic, only: %i[show] do
     member do


### PR DESCRIPTION
## 概要
Issue 59「ゲーム検索機能」の実装。Ransackを導入し、ヘッダーからゲームタイトルで検索できるようにした。通常の検索(一覧ページへの遷移)とリアルタイムのオートコンプリート候補表示の両方に対応。

## 変更内容

### 検索基盤
- Ransack導入(`Gemfile`)
- `Game`に`ransackable_attributes`/`ransackable_associations`を定義(`game_title`のみ検索可能、関連モデル跨ぎの検索は許可しない)
- `ApplicationController`の`before_action`で`@q`(検索条件オブジェクト)を全アクション共通でセット(ヘッダーの検索フォームがどのページでも機能するようにするため)
- 通常の検索送信は既存の`games#index`(ソート・ページネーション済み)にそのまま合流する形

### リアルタイムオートコンプリート
- `GET /games/search_suggestions`(`GamesController#search_suggestions`)を新設。`game_title`の部分一致で最大5件に絞って返す軽量エンドポイント
- Turbo Frame(`turbo_frame_tag "search_suggestions"`)+ Stimulus(`search_controller.js`)で、入力を300msデバウンスしてフレームの`src`を書き換え、候補を取得・表示
- 候補は`data: { turbo_frame: "_top" }`により、一覧ページを経由せず直接`games#show`に遷移
- 候補一覧にはバナー画像と積み率を表示(既存の一覧ページと同じ集計方法を使用)
- 検索欄以外をクリックした時、検索欄にフォーカスが戻った時、入力が空の時、の挙動を調整

## 動作確認
- 通常検索(送信→一覧ページでのフィルタ)の動作確認済み
- オートコンプリートの表示・候補クリックでの遷移確認済み
- 大文字小文字を区別しない検索(PostgreSQLの`ILIKE`)の確認済み

## 補足
- 全角/半角・かな正規化は今回は対応せず、必要になれば別途対応