### PR TITLE
Feature/63 tsumige state transition graph

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,9 +19,12 @@ class ApplicationController < ActionController::Base
   end
 
   def save_user_statistic_snapshot
+    return if session[:snapshot_recorded_on] == Date.current.to_s
+
     UserStatisticSnapshot.record_for(current_user)
-    rescue => e
-      Rails.logger.error(e.message)
+    session[:snapshot_recorded_on] = Date.current.to_s
+  rescue => e
+    Rails.logger.error(e.message)
   end
 
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ class ApplicationController < ActionController::Base
 
   before_action :authenticate_user!, unless: :devise_controller?
   before_action :set_search
+  before_action :save_user_statistic_snapshot, if: :user_signed_in?
 
   def after_sign_in_path_for(resource)
     loading_user_game_libraries_path
@@ -15,6 +16,12 @@ class ApplicationController < ActionController::Base
 
   def set_search
     @q = Game.ransack(params[:q])
+  end
+
+  def save_user_statistic_snapshot
+    UserStatisticSnapshot.record_for(current_user)
+    rescue => e
+      Rails.logger.error(e.message)
   end
 
 end

--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -17,6 +17,8 @@ class StatisticsController < ApplicationController
     cost_performance_ranking = UserGameLibrary.cost_performance_ranking(current_user)
     @best_cost_performance_games = cost_performance_ranking[:best]
     @worst_cost_performance_games = cost_performance_ranking[:worst]
+
+    @user_statistic_snapshots = current_user.user_statistic_snapshots.order(:recorded_on)
   end
 
   def cost_performance_detailed_ranking

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -16,6 +16,9 @@ application.register("search", SearchController)
 import ShopPreviewController from "./shop_preview_controller"
 application.register("shop-preview", ShopPreviewController)
 
+import SnapshotChartController from "./snapshot_chart_controller"
+application.register("snapshot-chart", SnapshotChartController)
+
 import ToastController from "./toast_controller"
 application.register("toast", ToastController)
 

--- a/app/javascript/controllers/snapshot_chart_controller.js
+++ b/app/javascript/controllers/snapshot_chart_controller.js
@@ -1,0 +1,58 @@
+import { Controller } from "@hotwired/stimulus"
+import { Chart } from "chart.js/auto"
+
+export default class extends Controller {
+  static targets = ["canvas"]
+  static values = { labels: Array, prices: Array, rates: Array }
+
+  connect() {
+    new Chart(this.canvasTarget, {
+      type: "line",
+      data: {
+        labels: this.labelsValue,
+        datasets: [
+          {
+            label: "積みゲー総額",
+            data: this.pricesValue,
+            borderColor: "#325C80",
+            backgroundColor: "#325C80",
+            yAxisID: "y"
+          },
+          {
+            label: "積み率(%)",
+            data: this.ratesValue,
+            borderColor: "#D6D9DC",
+            backgroundColor: "#D6D9DC",
+            yAxisID: "y1"
+          }
+        ]
+      },
+      options: {
+        color: "#fff",
+        plugins: {
+          legend: {
+            labels: { color: "#fff" }
+          }
+        },
+        scales: {
+          x: {
+            ticks: { color: "#fff" },
+            grid: { color: "rgba(255, 255, 255, 0.2)" }
+          },
+          y: {
+            type: "linear",
+            position: "left",
+            ticks: { color: "#fff" },
+            grid: { color: "rgba(255, 255, 255, 0.2)" }
+          },
+          y1: {
+            type: "linear",
+            position: "right",
+            ticks: { color: "#fff" },
+            grid: { drawOnChartArea: false }
+          }
+        }
+      }
+    })
+  }
+}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,7 @@ class User < ApplicationRecord
   has_many :user_gift_items, dependent: :destroy
   has_many :gift_items, through: :user_gift_items
   has_one :user_wallet, dependent: :destroy
+  has_many :user_statistic_snapshots, dependent: :destroy
 
   validates :name, presence: true
   validates :uid, presence: true, uniqueness: true

--- a/app/models/user_game_library.rb
+++ b/app/models/user_game_library.rb
@@ -62,6 +62,10 @@ class UserGameLibrary < ApplicationRecord
     user.user_game_libraries.unplayed.joins(:game).count
   end
 
+  def self.unplayed_rate(user)
+    user.user_game_libraries.unplayed.count.to_f / user.user_game_libraries.count.to_f * 100
+  end
+
   def self.unplayed_game_genres(user)
     libraries = user.user_game_libraries.unplayed.includes(game: :game_genre_types)
     genre_names = libraries.flat_map { |library| library.game.game_genre_types.map { |genre| genre.name } }

--- a/app/models/user_statistic_snapshot.rb
+++ b/app/models/user_statistic_snapshot.rb
@@ -1,0 +1,12 @@
+class UserStatisticSnapshot < ApplicationRecord
+  belongs_to :user
+
+  validates :recorded_on, uniqueness: { scope: :user_id }
+
+  def self.record_for(user)
+    find_or_create_by(user: user, recorded_on: Date.current) do |snapshot|
+      snapshot.total_price = UserGameLibrary.total_price(user)
+      snapshot.unplayed_rate = UserGameLibrary.unplayed_rate(user)
+    end
+  end
+end

--- a/app/views/statistics/show.html.slim
+++ b/app/views/statistics/show.html.slim
@@ -8,6 +8,13 @@ div.card.text-white.w-50.border-0.mx-auto.mt-5
     p.me-4 積みゲー本数: #{@unplayed_games.count}
     p.me-4 全体消化率: #{@cleared_game_count_rate.round(2)}%
 
+div.card.text-white.w-50.border-0.mx-auto.mt-5 data-controller="snapshot-chart" data-snapshot-chart-labels-value="#{@user_statistic_snapshots.pluck(:recorded_on).to_json}" data-snapshot-chart-prices-value="#{@user_statistic_snapshots.pluck(:total_price).to_json}" data-snapshot-chart-rates-value="#{@user_statistic_snapshots.pluck(:unplayed_rate).to_json}"
+  div.card-header.card-header-color.pb-0
+    p.p-1 積みゲー推移
+  div.card-body.card-body-color
+    div.rounded.p-2 style="background-color: #7d8791;"
+      canvas data-snapshot-chart-target="canvas"
+
 div.card.text-white.w-50.border-0.mx-auto.mt-5
   div.card-header.card-header-color.pb-0
     p.p-1 ネクストプレイ提案

--- a/db/migrate/20260808050112_create_user_statistic_snapshots.rb
+++ b/db/migrate/20260808050112_create_user_statistic_snapshots.rb
@@ -1,0 +1,14 @@
+class CreateUserStatisticSnapshots < ActiveRecord::Migration[7.2]
+  def change
+    create_table :user_statistic_snapshots do |t|
+      t.references :user, null: false, foreign_key: true
+      t.date :recorded_on, null: false
+      t.integer :total_price
+      t.decimal :unplayed_rate
+
+      t.timestamps
+    end
+
+    add_index :user_statistic_snapshots, [:user_id, :recorded_on], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_07_26_040356) do
+ActiveRecord::Schema[7.2].define(version: 2026_08_08_050112) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -189,6 +189,17 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_26_040356) do
     t.index ["user_id"], name: "index_user_outfit_items_on_user_id"
   end
 
+  create_table "user_statistic_snapshots", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.date "recorded_on", null: false
+    t.integer "total_price"
+    t.decimal "unplayed_rate"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id", "recorded_on"], name: "index_user_statistic_snapshots_on_user_id_and_recorded_on", unique: true
+    t.index ["user_id"], name: "index_user_statistic_snapshots_on_user_id"
+  end
+
   create_table "user_tasks", force: :cascade do |t|
     t.bigint "user_id"
     t.bigint "task_id"
@@ -232,6 +243,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_26_040356) do
   add_foreign_key "user_game_libraries", "users"
   add_foreign_key "user_outfit_items", "outfit_items"
   add_foreign_key "user_outfit_items", "users"
+  add_foreign_key "user_statistic_snapshots", "users"
   add_foreign_key "user_tasks", "tasks"
   add_foreign_key "user_tasks", "users"
   add_foreign_key "user_wallets", "users"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "autoprefixer": "^10.4.27",
     "bootstrap": "^5.3.8",
     "bootstrap-icons": "^1.13.1",
+    "chart.js": "^4.5.1",
     "nodemon": "^3.1.14",
     "postcss": "^8.5.8",
     "postcss-cli": "^11.0.1",

--- a/spec/factories/user_statistic_snapshots.rb
+++ b/spec/factories/user_statistic_snapshots.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :user_statistic_snapshot do
+    user { nil }
+    recorded_on { "2026-08-08" }
+    total_price { 1 }
+    unplayed_rate { "9.99" }
+  end
+end

--- a/spec/models/user_statistic_snapshot_spec.rb
+++ b/spec/models/user_statistic_snapshot_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe UserStatisticSnapshot, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -150,6 +150,11 @@
   resolved "https://registry.yarnpkg.com/@hotwired/turbo/-/turbo-8.0.23.tgz#a6eebc9ab4a5faadae265a4cbec8cfcb5731e77c"
   integrity sha512-GZ7cijxEZ6Ig71u7rD6LHaRv/wcE/hNsc+nEfiWOkLNqUgLOwo5MNGWOy5ZV9ZUDSiQx1no7YxjTNnT4O6//cQ==
 
+"@kurkle/color@^0.3.0":
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/@kurkle/color/-/color-0.3.4.tgz#4d4ff677e1609214fc71c580125ddddd86abcabf"
+  integrity sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==
+
 "@parcel/watcher-android-arm64@2.5.6":
   version "2.5.6"
   resolved "https://registry.yarnpkg.com/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz#5f32e0dba356f4ac9a11068d2a5c134ca3ba6564"
@@ -334,6 +339,13 @@ caniuse-lite@^1.0.30001774, caniuse-lite@^1.0.30001782:
   version "1.0.30001785"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001785.tgz#31f8e3ec1059430d2a7b04fff44c27672c4482df"
   integrity sha512-blhOL/WNR+Km1RI/LCVAvA73xplXA7ZbjzI4YkMK9pa6T/P3F2GxjNpEkyw5repTw9IvkyrjyHpwjnhZ5FOvYQ==
+
+chart.js@^4.5.1:
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-4.5.1.tgz#19dd1a9a386a3f6397691672231cb5fc9c052c35"
+  integrity sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==
+  dependencies:
+    "@kurkle/color" "^0.3.0"
 
 chokidar@^3.3.0, chokidar@^3.5.2:
   version "3.6.0"


### PR DESCRIPTION
## 概要
積みゲー総額・積みゲー率の推移をグラフで確認できる機能を追加。日々のスナップショットを記録し、時系列の折れ線グラフとして統計ページに表示する。

## 変更内容

### データ記録の仕組み
- `UserStatisticSnapshot`テーブルを新設(`user_id`, `recorded_on`, `total_price`, `unplayed_rate`)。`[user_id, recorded_on]`に一意インデックスを設定し、1ユーザー1日最大1件を保証
- `UserGameLibrary.unplayed_rate(user)`を新設(積みゲー率を算出)
- `UserStatisticSnapshot.record_for(user)`で「今日分がなければ記録する」を実装(`find_or_create_by`によるべき等な処理。同時アクセスによる一意制約違反は`rescue`で無視)
- 記録タイミングは、Sidekiqによる定期実行ではなく、`ApplicationController`の`before_action`で**ログイン済みユーザーのアクセス時に記録**する方式を採用。理由は以下の2点:
  - 本番(Render)でSidekiqのバックグラウンドワーカーが安定稼働確認できていないため
  - 使われていないアカウント分まで無駄に記録し続けることを避けられる
  - 毎リクエストDBに問い合わせるコストを避けるため、`session`に「今日は記録済みか」のフラグを持たせて軽量化

### グラフ表示
- Chart.jsを導入(`yarn add chart.js`)
- `statistics#show`に折れ線グラフのカードを追加。横軸を日付、縦軸を「積みゲー総額」「積み率」の2軸で表示
- Stimulusコントローラー(`snapshot_chart_controller.js`)で、ビュー側の`data-*-value`属性(JSON化した`recorded_on`/`total_price`/`unplayed_rate`の配列)を受け取り描画

## 動作確認
- 過去日付のダミースナップショットを一時投入し、複数点での折れ線表示を確認(確認後は削除済み)
- 未ログイン状態でのアクセス時にエラーが起きないことを確認済み