### PR TITLE
add:task_making_for_users

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -26,10 +26,11 @@ body {
 }
 
 .search-suggestion-item {
+    background-color: transparent;
     transition: background-color 0.15s ease-in-out;
 
     &:hover {
-        background-color: rgba(255, 255, 255, 0.1);
+        background-color: rgba(255, 255, 255, 0.35);
     }
 }
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,7 @@ class ApplicationController < ActionController::Base
   before_action :authenticate_user!, unless: :devise_controller?
   before_action :set_search
   before_action :save_user_statistic_snapshot, if: :user_signed_in?
+  before_action :set_now_playing_libraries, if: :user_signed_in?
 
   def after_sign_in_path_for(resource)
     loading_user_game_libraries_path
@@ -25,6 +26,10 @@ class ApplicationController < ActionController::Base
     session[:snapshot_recorded_on] = Date.current.to_s
   rescue => e
     Rails.logger.error(e.message)
+  end
+
+  def set_now_playing_libraries
+    @now_playing_libraries = current_user.user_game_libraries.now_playing.includes(:game)
   end
 
 end

--- a/app/controllers/play_focus_controller.rb
+++ b/app/controllers/play_focus_controller.rb
@@ -1,0 +1,46 @@
+class PlayFocusController < ApplicationController
+  def show
+    @next_up_library = current_user.user_game_libraries.next_up.includes(:game).first
+  end
+
+  def picker
+    @slot = params[:slot]
+    @cleared_filter = params[:cleared]
+    @available_libraries = current_user.user_game_libraries.unfocused.includes(:game).joins(:game).order('games.game_title')
+    @available_libraries = @available_libraries.where('games.game_title ILIKE ?', "%#{params[:q]}%") if params[:q].present?
+    @available_libraries = @available_libraries.cleared if @cleared_filter == 'cleared'
+    @available_libraries = @available_libraries.not_cleared if @cleared_filter == 'uncleared'
+  end
+
+  def set_slot
+    library = current_user.user_game_libraries.find(params[:library_id])
+
+    if library.update(play_focus: params[:slot])
+      redirect_to play_focus_path, notice: '設定しました。'
+    else
+      redirect_to play_focus_path, alert: library.errors.full_messages.to_sentence
+    end
+  end
+
+  def clear_slot
+    library = current_user.user_game_libraries.find(params[:library_id])
+    library.update(play_focus: :unfocused)
+    redirect_to play_focus_path, notice: '取り下げました。'
+  end
+
+  def update_cleared_games
+    library = current_user.user_game_libraries.find(params[:library_id])
+    library.update!(cleared_date: Time.current)
+    redirect_back fallback_location: play_focus_path, notice: 'クリア済みにしました。'
+  rescue
+    redirect_back fallback_location: play_focus_path, alert: '更新に失敗しました。'
+  end
+
+  def revert_cleared_games
+    library = current_user.user_game_libraries.find(params[:library_id])
+    library.update!(cleared_date: nil)
+    redirect_back fallback_location: play_focus_path, notice: '未クリアに戻しました。'
+  rescue
+    redirect_back fallback_location: play_focus_path, alert: '更新に失敗しました。'
+  end
+end

--- a/app/javascript/controllers/search_controller.js
+++ b/app/javascript/controllers/search_controller.js
@@ -2,6 +2,7 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   static targets = ["frame"]
+  static values = { url: String, clearOnEmpty: { type: Boolean, default: true } }
 
   connect() {
     this.closeOnOutsideClick = this.closeOnOutsideClick.bind(this)
@@ -16,18 +17,24 @@ export default class extends Controller {
     clearTimeout(this.timeout)
 
     const value = event.target.value.trim()
-    if (value === "") {
+    if (value === "" && this.clearOnEmptyValue) {
       this.frameTarget.innerHTML = ""
       this.frameTarget.removeAttribute("src")
       return
     }
 
     this.timeout = setTimeout(() => {
-        this.frameTarget.src = `/games/search_suggestions?q=${encodeURIComponent(value)}`
+        if (value === "") {
+          this.frameTarget.src = this.urlValue
+          return
+        }
+        const separator = this.urlValue.includes("?") ? "&" : "?"
+        this.frameTarget.src = `${this.urlValue}${separator}q=${encodeURIComponent(value)}`
     }, 300)
   }
 
   closeOnOutsideClick(event) {
+    if (!this.clearOnEmptyValue) return
     if (!this.element.contains(event.target)) {
       this.frameTarget.innerHTML = ""
       this.frameTarget.removeAttribute("src")

--- a/app/models/user_game_library.rb
+++ b/app/models/user_game_library.rb
@@ -4,12 +4,17 @@ class UserGameLibrary < ApplicationRecord
   RECOMMENDATION_COUNT = 3
   TSUMIGE_LIST_LIMIT = 10
   COST_PERFORMANCE_RANKING_LIMIT = 3
+  NOW_PLAYING_LIMIT = 3
+  NEXT_UP_LIMIT = 1
 
   belongs_to :user
   belongs_to :game
 
+  enum play_focus: { unfocused: 0, now_playing: 1, next_up: 2 }
+
   validates :game_id, uniqueness: { scope: :user_id }
   validates :minutes_played, numericality: { greater_than_or_equal_to: 0 }
+  validate :play_focus_slot_limit, if: :play_focus_changed?
 
   scope :not_recently_played, -> { where(last_played_at: nil).or(where('last_played_at < ?', 1.month.ago)) }
   scope :not_cleared, -> { where(cleared_date: nil)}
@@ -124,5 +129,16 @@ class UserGameLibrary < ApplicationRecord
     unplayed_time_array = game.user_game_libraries.unplayed.where.not(user_game_libraries: { unplayed_date: nil }).pluck(:unplayed_date).map { |date| (Date.current - date).to_i }
     return 0 if unplayed_time_array.empty?
     unplayed_time_array.sum.to_f / unplayed_time_array.size
+  end
+
+  private
+
+  def play_focus_slot_limit
+    return if unfocused?
+
+    limit = now_playing? ? NOW_PLAYING_LIMIT : NEXT_UP_LIMIT
+    current_count = user.user_game_libraries.where(play_focus: play_focus).where.not(id: id).count
+
+    errors.add(:play_focus, "の上限に達しています") if current_count >= limit
   end
 end

--- a/app/views/layouts/_header.slim
+++ b/app/views/layouts/_header.slim
@@ -11,6 +11,8 @@ nav.navbar.navbar-expand-lg.ps-3.fixed-top
           li
             = link_to '積みゲー総額', user_path, class: 'dropdown-item'
             = link_to '積みゲー統計', statistic_path, class: 'dropdown-item'
+            = link_to 'ゲーム一覧', games_path, class: 'dropdown-item'
+            = link_to 'プレイ状況', play_focus_path, class: 'dropdown-item'
 
       div.dropdown.pe-3
         button.btn.btn-secondary.dropdown-toggle.text-white.me-3 type="button" data-bs-toggle="dropdown" aria-expanded="false" 積みゲーマイレージ
@@ -24,10 +26,15 @@ nav.navbar.navbar-expand-lg.ps-3.fixed-top
         button.btn.btn-secondary.dropdown-toggle.text-white type="button" data-bs-toggle="dropdown" aria-expanded="false" #{current_user.name}
         ul.dropdown-menu
           li
+            - if @now_playing_libraries.present?
+              - @now_playing_libraries.each do |library|
+                = link_to "今プレイ中のゲーム: #{library.game.game_title}", play_focus_path, class: 'dropdown-item'
+            - else
+              = link_to '今プレイ中のゲーム: 未設定', play_focus_path, class: 'dropdown-item'
             = link_to 'ログアウト', destroy_user_session_path, class: 'dropdown-item', data: {turbo_method: :delete}
             = link_to 'アカウント削除', user_path , class: 'dropdown-item', data: {turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }
 
-      div.position-relative data-controller="search"
+      div.position-relative data-controller="search" data-search-url-value=search_suggestions_games_path
         = search_form_for @q, html: { class: "d-flex align-items-center" } do |f|
           = f.search_field :game_title_cont, data: { action: "input->search#search focus->search#search" }, class: "search-input rounded me-2", placeholder: "ゲームを検索", autocomplete: "off"
           = f.submit "検索", class: "btn btn-color text-white"

--- a/app/views/play_focus/picker.html.slim
+++ b/app/views/play_focus/picker.html.slim
@@ -1,0 +1,32 @@
+div.card.text-white.w-50.border-0.mx-auto.mt-5 data-controller="search" data-search-url-value=picker_play_focus_path(slot: @slot, cleared: @cleared_filter) data-search-clear-on-empty-value="false"
+  div.card-header.card-header-color.pb-0
+    p.p-1 ゲームを選択
+  div.d-flex.gap-3.px-3.pb-2.card-header-color
+    = link_to 'すべて', picker_play_focus_path(slot: @slot, q: params[:q]), class: 'text-white'
+    = link_to '未クリア', picker_play_focus_path(slot: @slot, q: params[:q], cleared: 'uncleared'), class: 'text-white'
+    = link_to 'クリア済み', picker_play_focus_path(slot: @slot, q: params[:q], cleared: 'cleared'), class: 'text-white'
+
+  div.card-body.card-body-color
+    = form_with url: picker_play_focus_path, method: :get, class: "d-flex align-items-center mb-3" do |f|
+      = hidden_field_tag :slot, @slot
+      = hidden_field_tag :cleared, @cleared_filter
+      = f.search_field :q, value: params[:q], data: { action: "input->search#search" }, class: "search-input rounded me-2", placeholder: "ゲームを検索", autocomplete: "off"
+      = f.submit "検索", class: "btn btn-color text-white"
+
+    = turbo_frame_tag "picker_results", data: { search_target: "frame" } do
+      ul.list-unstyled.w-100.px-3
+        - @available_libraries.each do |library|
+          li.mb-2.d-flex.align-items-center.justify-content-between
+            = button_to set_slot_play_focus_path(library_id: library.id, slot: @slot), method: :patch, form: { data: { turbo_frame: "_top" } }, class: "search-suggestion-item d-flex align-items-center text-white text-decoration-none p-2 border-0 text-start flex-grow-1" do
+              = image_tag steam_thumbnail_image(library.game), class: 'me-3', style: 'width: 92px; height: 35px; object-fit: cover;', onerror: "this.onerror=null;this.src='#{broken_thumbnail_placeholder}'"
+              div
+                div = library.game.game_title
+                div.small = "プレイ時間: #{(library.minutes_played / 60.0).round(1)}時間 / 価格: ¥#{library.game.price} / #{library.cleared_date ? 'クリア済み' : '未クリア'}"
+                - if library.unplayed_date && library.cleared_date.nil?
+                  div.small = "積み時間: #{(Date.current - library.unplayed_date).to_i}日"
+            - if library.cleared_date
+              = button_to "未クリアに戻す", revert_cleared_games_play_focus_path(library_id: library.id), method: :patch, class: "btn btn-secondary text-white btn-sm ms-2"
+            - else
+              = button_to "クリアにする", update_cleared_games_play_focus_path(library_id: library.id), method: :patch, class: "btn btn-secondary text-white btn-sm ms-2"
+
+    = link_to "戻る", play_focus_path, class: "btn btn-secondary text-white mt-3"

--- a/app/views/play_focus/show.html.slim
+++ b/app/views/play_focus/show.html.slim
@@ -1,0 +1,47 @@
+div.card.text-white.w-50.border-0.mx-auto.mt-5
+  div.card-header.card-header-color.pb-0
+    p.p-1 プレイ状況
+
+  div.card-body.card-body-color
+    h6.text-white 今プレイ中のゲーム
+    div.d-flex.flex-column.gap-2.mb-4
+      - (1..UserGameLibrary::NOW_PLAYING_LIMIT).each do |i|
+        - library = @now_playing_libraries[i - 1]
+        div.border.border-secondary.rounded.p-2
+          - if library
+            div.d-flex.align-items-center.justify-content-between
+              div.d-flex.align-items-center
+                = image_tag steam_thumbnail_image(library.game), class: 'me-3', style: 'width: 92px; height: 35px; object-fit: cover;', onerror: "this.onerror=null;this.src='#{broken_thumbnail_placeholder}'"
+                div
+                  div = library.game.game_title
+                  div.small = "プレイ時間: #{(library.minutes_played / 60.0).round(1)}時間"
+                  div.small = "価格: ¥#{library.game.price}"
+                  - if library.cleared_date
+                    div.small クリア済み
+                  - else
+                    div.small 未クリア
+                  - if library.unplayed_date && library.cleared_date.nil?
+                    div.small = "積み時間: #{(Date.current - library.unplayed_date).to_i}日"
+              div.d-flex.flex-column.gap-1
+                - if library.cleared_date
+                  = button_to "未クリアに戻す", revert_cleared_games_play_focus_path(library_id: library.id), method: :patch, class: "btn btn-color text-white btn-sm"
+                - else
+                  = button_to "クリアにする", update_cleared_games_play_focus_path(library_id: library.id), method: :patch, class: "btn btn-color text-white btn-sm"
+                = button_to "取り下げる", clear_slot_play_focus_path(library_id: library.id), method: :patch, class: "btn btn-secondary text-white btn-sm"
+          - else
+            = link_to "ゲームを選択", picker_play_focus_path(slot: 'now_playing'), class: "btn btn-color text-white"
+
+    h6.text-white 次にプレイするゲーム
+    div.border.border-secondary.rounded.p-2
+      - if @next_up_library
+        div.d-flex.align-items-center.justify-content-between
+          div.d-flex.align-items-center
+            = image_tag steam_thumbnail_image(@next_up_library.game), class: 'me-3', style: 'width: 92px; height: 35px; object-fit: cover;', onerror: "this.onerror=null;this.src='#{broken_thumbnail_placeholder}'"
+            div
+              div = @next_up_library.game.game_title
+              div.small = "プレイ時間: #{(@next_up_library.minutes_played / 60.0).round(1)}時間"
+              div.small = "価格: ¥#{@next_up_library.game.price}"
+          div.d-flex.flex-column.gap-1
+            = button_to "取り下げる", clear_slot_play_focus_path(library_id: @next_up_library.id), method: :patch, class: "btn btn-secondary text-white btn-sm"
+      - else
+        = link_to "ゲームを選択", picker_play_focus_path(slot: 'next_up'), class: "btn btn-color text-white"

--- a/app/views/statistics/show.html.slim
+++ b/app/views/statistics/show.html.slim
@@ -25,7 +25,7 @@ div.card.text-white.w-50.border-0.mx-auto.mt-5
     ol.w-100.px-3
       - @recommended_games.each do |library|
         li.d-flex.justify-content-between
-          span = library.game.game_title
+          span = link_to library.game.game_title, game_path(library.game), class: 'text-white'
           - if library.last_played_at
             span = library.last_played_at&.strftime('%Y年%m月%d日')
           - else
@@ -56,7 +56,7 @@ div.card.text-white.w-50.border-0.mx-auto.mt-5
       ol.w-100.px-3
         - @unplayed_games.each do |library|
           li.d-flex.justify-content-between
-            span.col-6 = library.game.game_title
+            span.col-6 = link_to library.game.game_title, game_path(library.game), class: 'text-white'
             span.col-6 = "#{(library.minutes_played/60.0).round(1)}時間"
             span.col-6 = check_box_tag "cleared_game_ids[]", library.id
       = f.submit "更新する"
@@ -68,7 +68,7 @@ div.card.text-white.w-50.border-0.mx-auto.mt-5
     ol.w-100.px-3
       - @cleared_after_unplayed_games.each do |library|
         li.d-flex.justify-content-between
-          span.col-6 = library.game.game_title
+          span.col-6 = link_to library.game.game_title, game_path(library.game), class: 'text-white'
           span.col-6 = "#{(library.minutes_played/60.0).round(1)}時間"
           span.col-6 = "#{(library.cleared_date - library.unplayed_date).to_i}日"
 
@@ -79,13 +79,13 @@ div.card.text-white.w-50.border-0.mx-auto.mt-5
     ol.w-100.px-3
       - @best_cost_performance_games.each do |library|
         li.d-flex.justify-content-between
-          span.col-6 = library.game.game_title
+          span.col-6 = link_to library.game.game_title, game_path(library.game), class: 'text-white'
           span.col-6 = "¥#{library.game.price}"
           span.col-6 = "#{(library.minutes_played/60.0).round(1)}時間"
           span.col-6 = "#{(((library.minutes_played + 1).to_f / library.game.price)*1000).round(2)}"
       - @worst_cost_performance_games.each do |library|
         li.d-flex.justify-content-between
-          span.col-6 = library.game.game_title
+          span.col-6 = link_to library.game.game_title, game_path(library.game), class: 'text-white'
           span.col-6 = "¥#{library.game.price}"
           span.col-6 = "#{(library.minutes_played/60.0).round(1)}時間"
           span.col-6 = "#{(((library.minutes_played + 1).to_f / library.game.price)*1000).round(2)}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,16 @@ Rails.application.routes.draw do
     end
   end
 
+  resource :play_focus, only: %i[show] do
+    member do
+      get 'picker'
+      patch 'set_slot'
+      patch 'clear_slot'
+      patch 'update_cleared_games'
+      patch 'revert_cleared_games'
+    end
+  end
+
   resources :tasks, only: %i[index show] do
     collection do
       patch 'obtain_all_rewards'

--- a/db/migrate/20260809013801_add_play_focus_to_user_game_libraries.rb
+++ b/db/migrate/20260809013801_add_play_focus_to_user_game_libraries.rb
@@ -1,0 +1,5 @@
+class AddPlayFocusToUserGameLibraries < ActiveRecord::Migration[7.2]
+  def change
+    add_column :user_game_libraries, :play_focus, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_08_08_050112) do
+ActiveRecord::Schema[7.2].define(version: 2026_08_09_013801) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -165,6 +165,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_08_050112) do
     t.datetime "last_played_at"
     t.date "cleared_date"
     t.date "unplayed_date"
+    t.integer "play_focus", default: 0, null: false
     t.index ["game_id"], name: "index_user_game_libraries_on_game_id"
     t.index ["user_id", "game_id"], name: "index_user_game_libraries_on_user_id_and_game_id", unique: true
     t.index ["user_id"], name: "index_user_game_libraries_on_user_id"


### PR DESCRIPTION
## 概要
積みゲー消化を後押しするための「プレイ状況管理」機能を追加。同時に触るゲームを「今プレイ中(最大3本)」「次にプレイする(1本)」に絞って設定できるようにし、そこからクリアフラグの管理もできるようにした。

## 変更内容

### データモデル
- `UserGameLibrary`に`play_focus`(enum: `unfocused`/`now_playing`/`next_up`)を追加。1つの値しか持てない構造上、同じゲームが「今プレイ中」と「次にプレイする」を同時に持つことはない
- 自作バリデーション(`play_focus_slot_limit`)で、`now_playing`は3件まで、`next_up`は1件までに制限。`play_focus`が実際に変更される時だけ検証するようにし、無関係な保存(プレイ時間の同期など)での無駄なチェックを避けた

### 専用ページ(`/play_focus`)
- 「今プレイ中」3枠+「次にプレイする」1枠を表示。各枠にバナー画像・プレイ時間・価格・クリア状態・積み時間を表示
- 「クリアにする」⇔「未クリアに戻す」がクリア状態に応じて切り替わるボタンで、誤操作の取り消しができる
- 「取り下げる」ボタンで枠から解除

### ゲーム選択画面(`/play_focus/picker`)
- 所持ゲームのうちどの枠にも入っていないもの(`unfocused`)を50音順+サムネイル付きで一覧表示、行全体をクリックすると即座に対象の枠に設定される
- リアルタイム検索(Turbo Frame + Stimulusのデバウンス)に対応。既存のヘッダー検索用`search_controller.js`を、対象URLを外部から指定できるよう汎用化して再利用した
- 「すべて/未クリア/クリア済み」フィルタを`games#index`のソートリンクと同じスタイルで実装
- 各行から直接クリアフラグの切り替えも可能

### ヘッダーへの導線
- 「積みゲー分析」プルダウンに「プレイ状況」「ゲーム一覧」リンクを追加
- ユーザー名プルダウンに「今プレイ中のゲーム: ○○」を表示し、`/play_focus`への導線に

### 副次的な修正
- 統計ページのゲームタイトルに、詳細ページ(`games#show`)へのリンクが無かったため追加

## 動作確認
- 今プレイ中/次にプレイするの設定・上限・取り下げ・クリア切り替えを確認済み
- ゲーム選択画面の検索・フィルタ・行クリックでの遷移を確認済み

## 保留事項
- 将来的にゲーム詳細画面との統合を検討
- f積みゲー統計画面の積みゲーリストとも機能が被っているため、そちらの調整も要検討