### PR TITLE
add:積みゲー推移グラフに表示期間切り替え機能を追加

### DIFF
--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -1,4 +1,13 @@
 class StatisticsController < ApplicationController
+  CHART_RANGES = {
+    'week' => 1.week,
+    'month' => 1.month,
+    'half_year' => 6.months,
+    'year' => 1.year,
+    'all' => nil
+  }.freeze
+  DEFAULT_CHART_RANGE = 'month'
+
   def show
     @user = current_user
     @total_price = UserGameLibrary.total_price(current_user)
@@ -20,7 +29,10 @@ class StatisticsController < ApplicationController
     @best_cost_performance_games = cost_performance_ranking[:best]
     @worst_cost_performance_games = cost_performance_ranking[:worst]
 
+    @chart_range = CHART_RANGES.key?(params[:chart_range]) ? params[:chart_range] : DEFAULT_CHART_RANGE
     @user_statistic_snapshots = current_user.user_statistic_snapshots.order(:recorded_on)
+    duration = CHART_RANGES[@chart_range]
+    @user_statistic_snapshots = @user_statistic_snapshots.where(recorded_on: duration.ago..) if duration
   end
 
   def cost_performance_detailed_ranking

--- a/app/views/statistics/show.html.slim
+++ b/app/views/statistics/show.html.slim
@@ -38,6 +38,9 @@ div.mx-auto.mt-5 style="max-width: 960px;"
       p.p-1.fs-4.mb-0
         i.bi.bi-graph-up.me-2
         | 積みゲー推移
+    div.d-flex.gap-3.px-3.pb-2.card-header-color
+      - [['1週間', 'week'], ['1か月', 'month'], ['半年', 'half_year'], ['1年', 'year'], ['全期間', 'all']].each do |label, key|
+        = link_to label, statistic_path(chart_range: key), class: key == @chart_range ? 'text-white fw-bold' : 'link-steam-accent'
     div.card-body.card-body-color.p-4
       div.rounded.p-3 style="background-color: #8b929b; box-shadow: 0 6px 14px rgba(0, 0, 0, 0.35);"
         canvas data-snapshot-chart-target="canvas"


### PR DESCRIPTION
## 概要
- 統計ページ(`/statistic`)の「積みゲー推移」グラフに、表示期間を切り替えるUIを追加
- デフォルトの表示期間は「直近30日」
- 選択肢: 1週間 / 1か月(デフォルト) / 半年 / 1年 / 全期間

## 変更内容
- `StatisticsController#show`に`CHART_RANGES`定数を追加し、`params[:chart_range]`に応じて`@user_statistic_snapshots`を`recorded_on`で絞り込むように変更
- 不正な値が渡された場合は`month`(直近30日)にフォールバック
- ビュー側に期間選択リンクを追加(`games#index`のソートリンクと同じ`.card-header-color` + `.link-steam-accent`パターン、選択中の項目は白太字で強調)
- ページ全体のGETリクエストで切り替える方式(Turbo Frame化はせず、シンプルな実装を優先)

## テスト計画
- [x] `/statistic`にアクセスし、デフォルトで直近30日分のグラフが表示されることを確認
- [ ] 各期間リンク(1週間/1か月/半年/1年/全期間)をクリックし、グラフのデータ点数が期間に応じて変わることを確認
- [x] 選択中の期間リンクが白太字でハイライトされることを確認
- [ ] 積みゲー推移データが1件もない/少ない場合でもエラーにならないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)