### PR TITLE
fix:積みゲー推移グラフの期間をカレンダー単位に変更しTurbo Frame化

### DIFF
--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -1,12 +1,7 @@
 class StatisticsController < ApplicationController
-  CHART_RANGES = {
-    'week' => 1.week,
-    'month' => 1.month,
-    'half_year' => 6.months,
-    'year' => 1.year,
-    'all' => nil
-  }.freeze
+  CHART_RANGES = %w[week month half_year year all].freeze
   DEFAULT_CHART_RANGE = 'month'
+  CHART_RANGE_OFFSET_OPTIONS_COUNT = 12
 
   def show
     @user = current_user
@@ -29,10 +24,13 @@ class StatisticsController < ApplicationController
     @best_cost_performance_games = cost_performance_ranking[:best]
     @worst_cost_performance_games = cost_performance_ranking[:worst]
 
-    @chart_range = CHART_RANGES.key?(params[:chart_range]) ? params[:chart_range] : DEFAULT_CHART_RANGE
+    @chart_range = CHART_RANGES.include?(params[:chart_range]) ? params[:chart_range] : DEFAULT_CHART_RANGE
+    @chart_range_offset = @chart_range == 'all' ? 0 : params[:chart_range_offset].to_i.clamp(0, CHART_RANGE_OFFSET_OPTIONS_COUNT - 1)
+    @chart_range_options = chart_range_offset_options(@chart_range)
+
     @user_statistic_snapshots = current_user.user_statistic_snapshots.order(:recorded_on)
-    duration = CHART_RANGES[@chart_range]
-    @user_statistic_snapshots = @user_statistic_snapshots.where(recorded_on: duration.ago..) if duration
+    start_date, end_date = chart_range_period(@chart_range, @chart_range_offset)
+    @user_statistic_snapshots = @user_statistic_snapshots.where(recorded_on: start_date..end_date) if start_date
   end
 
   def cost_performance_detailed_ranking
@@ -58,5 +56,50 @@ class StatisticsController < ApplicationController
 
   rescue #update!で例外エラーが発生したときの処理 beginが省略されている rescue単体にendは不要
     redirect_to statistic_path, alert: 'クリア済みゲームの更新に失敗しました。'
+  end
+
+  private
+
+  def chart_range_period(range, offset)
+    today = Date.current
+    case range
+    when 'week'
+      start_date = today.beginning_of_week - offset.weeks
+      [start_date, start_date.end_of_week]
+    when 'month'
+      start_date = today.beginning_of_month - offset.months
+      [start_date, start_date.end_of_month]
+    when 'half_year'
+      current_half_start = today.month <= 6 ? today.beginning_of_year : today.beginning_of_year + 6.months
+      start_date = current_half_start - (offset * 6).months
+      [start_date, start_date + 6.months - 1.day]
+    when 'year'
+      start_date = today.beginning_of_year - offset.years
+      [start_date, start_date.end_of_year]
+    else
+      [nil, nil]
+    end
+  end
+
+  def chart_range_offset_options(range)
+    return [] if range == 'all'
+
+    (0...CHART_RANGE_OFFSET_OPTIONS_COUNT).map do |offset|
+      start_date, end_date = chart_range_period(range, offset)
+      [chart_range_period_label(range, start_date, end_date), offset]
+    end
+  end
+
+  def chart_range_period_label(range, start_date, end_date)
+    case range
+    when 'week'
+      "#{start_date.strftime('%-m/%-d')}〜#{end_date.strftime('%-m/%-d')}"
+    when 'month'
+      "#{start_date.year}年#{start_date.month}月"
+    when 'half_year'
+      "#{start_date.year}年#{start_date.month <= 6 ? '上半期' : '下半期'}"
+    when 'year'
+      "#{start_date.year}年"
+    end
   end
 end

--- a/app/views/statistics/show.html.slim
+++ b/app/views/statistics/show.html.slim
@@ -33,18 +33,23 @@ div.mx-auto.mt-5 style="max-width: 960px;"
           | 全体消化率
         div.fs-4.fw-bold = "#{@cleared_game_count_rate.round(2)}%"
 
-  div.card.text-white.border-0.mb-5 data-controller="snapshot-chart" data-snapshot-chart-labels-value="#{@user_statistic_snapshots.pluck(:recorded_on).to_json}" data-snapshot-chart-prices-value="#{@user_statistic_snapshots.pluck(:total_price).to_json}" data-snapshot-chart-rates-value="#{@user_statistic_snapshots.pluck(:unplayed_rate).to_json}"
-    div.card-header.card-header-color.py-3
-      p.p-1.fs-4.mb-0
-        i.bi.bi-graph-up.me-2
-        | 積みゲー推移
-    div.d-flex.gap-3.px-3.pb-2.card-header-color
-      - [['1週間', 'week'], ['1か月', 'month'], ['半年', 'half_year'], ['1年', 'year'], ['全期間', 'all']].each do |label, key|
-        = link_to label, statistic_path(chart_range: key), class: key == @chart_range ? 'text-white fw-bold' : 'link-steam-accent'
-    div.card-body.card-body-color.p-4
-      div.rounded.p-3 style="background-color: #8b929b; box-shadow: 0 6px 14px rgba(0, 0, 0, 0.35);"
-        canvas data-snapshot-chart-target="canvas"
-      p.small.text-muted-steam.mt-2.mb-0 ※1日1度サイトへアクセス時に積みゲー総額と積みゲー率が記録されます。アクセスがなかった日は記録されません。
+  = turbo_frame_tag "snapshot_chart" do
+    div.card.text-white.border-0.mb-5 data-controller="snapshot-chart" data-snapshot-chart-labels-value="#{@user_statistic_snapshots.pluck(:recorded_on).to_json}" data-snapshot-chart-prices-value="#{@user_statistic_snapshots.pluck(:total_price).to_json}" data-snapshot-chart-rates-value="#{@user_statistic_snapshots.pluck(:unplayed_rate).to_json}"
+      div.card-header.card-header-color.py-3
+        p.p-1.fs-4.mb-0
+          i.bi.bi-graph-up.me-2
+          | 積みゲー推移
+      div.d-flex.flex-wrap.align-items-center.gap-3.px-3.pb-2.card-header-color
+        - [['1週間', 'week'], ['1か月', 'month'], ['半年', 'half_year'], ['1年', 'year'], ['全期間', 'all']].each do |label, key|
+          = link_to label, statistic_path(chart_range: key), class: key == @chart_range ? 'text-white fw-bold' : 'link-steam-accent'
+        - if @chart_range_options.any?
+          = form_with url: statistic_path, method: :get, class: "ms-auto" do |f|
+            = hidden_field_tag :chart_range, @chart_range
+            = select_tag :chart_range_offset, options_for_select(@chart_range_options, @chart_range_offset), class: "form-select form-select-sm w-auto", onchange: "this.form.requestSubmit()"
+      div.card-body.card-body-color.p-4
+        div.rounded.p-3 style="background-color: #8b929b; box-shadow: 0 6px 14px rgba(0, 0, 0, 0.35);"
+          canvas data-snapshot-chart-target="canvas"
+        p.small.text-muted-steam.mt-2.mb-0 ※1日1度サイトへアクセス時に積みゲー総額と積みゲー率が記録されます。アクセスがなかった日は記録されません。
 
   div.row.g-5.mb-5
     div.col-lg-6


### PR DESCRIPTION
## 概要
- 積みゲー推移グラフの期間切り替えをTurbo Frame化し、クリック時にページ遷移を挟まないように変更
- 期間の絞り込みを「直近N日」方式から、暦週/暦月/上半期・下半期/暦年での絞り込みに変更
  - 1週間→その週(月〜日)、1か月→その月、半年→上半期(1〜6月)/下半期(7〜12月)、1年→その年、全期間→全データ
- 各期間について過去の期間を遡って選択できるプルダウンを追加(直近12期間分)

## テスト計画
- [ ] 期間リンク(1週間/1か月/半年/1年/全期間)クリック時にページ全体が再読み込みされず、グラフ部分だけ切り替わることを確認
- [ ] 各モードのプルダウンに正しい期間ラベル(例: 「8/3〜8/9」「2026年8月」「2026年上半期」「2026年」)が並ぶことを確認
- [ ] プルダウンで過去の期間を選択すると、その期間のデータに切り替わることを確認
- [ ] 全期間モードではプルダウンが表示されないことを確認
- [ ] データが少ない期間でも、期間の区切りが暦通り(月初〜月末など)になっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)