### PR TITLE
fix:積みゲー推移グラフのx軸を期間全体で表示するよう変更

### DIFF
--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -31,6 +31,7 @@ class StatisticsController < ApplicationController
     @user_statistic_snapshots = current_user.user_statistic_snapshots.order(:recorded_on)
     start_date, end_date = chart_range_period(@chart_range, @chart_range_offset)
     @user_statistic_snapshots = @user_statistic_snapshots.where(recorded_on: start_date..end_date) if start_date
+    @chart_labels, @chart_prices, @chart_rates = chart_series(@user_statistic_snapshots, start_date, end_date)
   end
 
   def cost_performance_detailed_ranking
@@ -59,6 +60,16 @@ class StatisticsController < ApplicationController
   end
 
   private
+
+  def chart_series(snapshots, start_date, end_date)
+    return [snapshots.pluck(:recorded_on), snapshots.pluck(:total_price), snapshots.pluck(:unplayed_rate)] unless start_date
+
+    snapshots_by_date = snapshots.index_by(&:recorded_on)
+    dates = (start_date..end_date).to_a
+    prices = dates.map { |date| snapshots_by_date[date]&.total_price }
+    rates = dates.map { |date| snapshots_by_date[date]&.unplayed_rate }
+    [dates, prices, rates]
+  end
 
   def chart_range_period(range, offset)
     today = Date.current

--- a/app/views/statistics/show.html.slim
+++ b/app/views/statistics/show.html.slim
@@ -34,7 +34,7 @@ div.mx-auto.mt-5 style="max-width: 960px;"
         div.fs-4.fw-bold = "#{@cleared_game_count_rate.round(2)}%"
 
   = turbo_frame_tag "snapshot_chart" do
-    div.card.text-white.border-0.mb-5 data-controller="snapshot-chart" data-snapshot-chart-labels-value="#{@user_statistic_snapshots.pluck(:recorded_on).to_json}" data-snapshot-chart-prices-value="#{@user_statistic_snapshots.pluck(:total_price).to_json}" data-snapshot-chart-rates-value="#{@user_statistic_snapshots.pluck(:unplayed_rate).to_json}"
+    div.card.text-white.border-0.mb-5 data-controller="snapshot-chart" data-snapshot-chart-labels-value="#{@chart_labels.to_json}" data-snapshot-chart-prices-value="#{@chart_prices.to_json}" data-snapshot-chart-rates-value="#{@chart_rates.to_json}"
       div.card-header.card-header-color.py-3
         p.p-1.fs-4.mb-0
           i.bi.bi-graph-up.me-2


### PR DESCRIPTION
## 概要
- 積みゲー推移グラフのx軸が実データの範囲(例: 8/8〜8/9)にしか広がらず、選択した期間全体が見えない問題を修正
- 選択期間内の全日付をラベルとして生成し、データがない日は値を空にすることで、x軸が期間全体(例: 1か月なら月初〜月末)をカバーするように変更
- 「全期間」モードは期間の境界がないため、従来通り実データの日付のみを表示

## テスト計画
- [ ] 1か月モードで、データが数日分しかない場合でもx軸の左端が月初、右端が月末になっていることを確認
- [ ] 半年・1年モードでも同様に期間全体がx軸に表示されることを確認
- [ ] 全期間モードは従来通り実データの範囲のみ表示されることを確認
- [ ] データがない日の折れ線が途切れて表示され、エラーにならないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)