### PR TITLE
fix:積みゲー推移グラフでデータのない日をまたいで線をつなげる

### DIFF
--- a/app/javascript/controllers/snapshot_chart_controller.js
+++ b/app/javascript/controllers/snapshot_chart_controller.js
@@ -16,14 +16,16 @@ export default class extends Controller {
             data: this.pricesValue,
             borderColor: "#325C80",
             backgroundColor: "#325C80",
-            yAxisID: "y"
+            yAxisID: "y",
+            spanGaps: true
           },
           {
             label: "積み率(%)",
             data: this.ratesValue,
             borderColor: "#D6D9DC",
             backgroundColor: "#D6D9DC",
-            yAxisID: "y1"
+            yAxisID: "y1",
+            spanGaps: true
           }
         ]
       },


### PR DESCRIPTION
## 概要
- 積みゲー推移グラフで、データが存在しない日を挟むと前後の点の線が途切れて表示されていた問題を修正
- Chart.jsの`spanGaps: true`を指定し、データがない日があっても前後の実データ同士を線でつなげるように変更

## テスト計画
- [ ] データが飛び飛びの日(例: 8/9と8/11のみ記録があり8/10は記録がない)でも、線が途切れずつながって表示されることを確認
- [ ] 積みゲー総額・積み率どちらのグラフも同様につながることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)