### PR TITLE
add:ネクストプレイ提案から「次にプレイするゲーム」を直接設定できるボタンを追加

### DIFF
--- a/app/controllers/play_focus_controller.rb
+++ b/app/controllers/play_focus_controller.rb
@@ -16,6 +16,10 @@ class PlayFocusController < ApplicationController
   def set_slot
     library = current_user.user_game_libraries.find(params[:library_id])
 
+    if params[:slot] == 'next_up'
+      current_user.user_game_libraries.next_up.where.not(id: library.id).update_all(play_focus: :unfocused)
+    end
+
     if library.update(play_focus: params[:slot])
       redirect_to play_focus_path, notice: '設定しました。'
     else

--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -10,6 +10,7 @@ class StatisticsController < ApplicationController
     @total_games_count = current_user.user_game_libraries.count
     @unplayed_rate = UserGameLibrary.unplayed_rate(current_user)
     @recommended_games = current_user.user_game_libraries.unplayed.cheapest_games.recommend_3
+    @next_up_library = current_user.user_game_libraries.next_up.first
     @cleared_after_unplayed_games = current_user.user_game_libraries.cleared_after_unplayed.includes(:game)
 
     @cleared_game_count_rate = UserGameLibrary.cleared_game_count_rate(current_user)

--- a/app/views/statistics/show.html.slim
+++ b/app/views/statistics/show.html.slim
@@ -61,11 +61,18 @@ div.mx-auto.mt-5 style="max-width: 960px;"
         div.card-body.card-body-color.d-flex.flex-column.gap-3
           - @recommended_games.each do |library|
             div.p-3.rounded.stat-tile.d-flex.justify-content-between.align-items-center
-              = link_to library.game.game_title, game_path(library.game), class: 'link-steam-accent fs-5 fw-bold'
-              - if library.last_played_at
-                span.text-muted-steam = library.last_played_at&.strftime('%Y年%m月%d日')
+              div
+                = link_to library.game.game_title, game_path(library.game), class: 'link-steam-accent fs-5 fw-bold'
+                - if library.last_played_at
+                  div.text-muted-steam = library.last_played_at&.strftime('%Y年%m月%d日')
+                - else
+                  div.text-muted-steam 未プレイ
+              - if library.next_up?
+                div.d-flex.align-items-center.gap-2
+                  span.small.text-muted-steam 設定中
+                  = button_to "取り下げる", clear_slot_play_focus_path(library_id: library.id), method: :patch, class: "btn btn-secondary text-white btn-sm"
               - else
-                span.text-muted-steam 未プレイ
+                = button_to "次にプレイに設定", set_slot_play_focus_path(library_id: library.id, slot: 'next_up'), method: :patch, class: "btn btn-color text-white btn-sm", form: { data: { turbo_confirm: (@next_up_library ? "「#{@next_up_library.game.game_title}」から「#{library.game.game_title}」に変更しますか?" : nil) } }
 
     div.col-lg-6
       div.card.text-white.border-0.h-100


### PR DESCRIPTION
## Summary
- 積みゲー統計画面の「ネクストプレイ提案」の各ゲームから、プレイ状況管理機能の「次にプレイするゲーム」(next_upスロット)へワンクリックで設定・解除できるボタンを追加
- 既にnext_upスロットに別のゲームが設定されている場合は、set_slot実行時に既存の設定を自動的に解除してから新しいゲームを設定するよう変更(上限1件のバリデーションに引っかからないようにするため)
- 既にnext_up設定中の提案ゲームには「設定中」ラベルと「取り下げる」ボタンを表示

## 変更点
- `app/controllers/statistics_controller.rb`: `@next_up_library`(現在next_upに設定されているライブラリ)をshowアクションに追加
- `app/controllers/play_focus_controller.rb`: `set_slot`で`slot: 'next_up'`指定時、自分以外の既存next_upレコードを`unfocused`に戻してから更新するよう修正
- `app/views/statistics/show.html.slim`: ネクストプレイ提案カードの各行に、上記アクションを呼ぶボタンを追加。既に別ゲームがnext_up設定中の場合は上書き確認ダイアログ(`turbo_confirm`)を表示

## Test plan
- [x] 積みゲー統計画面で「次にプレイに設定」を押し、`/play_focus`のネクストプレイ枠に反映されることを確認
- [x] 既にnext_upが設定済みの状態で別ゲームの「次にプレイに設定」を押すと、確認ダイアログが出て、OKで上書きされることを確認
- [x] 設定中のゲームに「取り下げる」ボタンが表示され、押すとnext_upが解除されることを確認
- [x] `NEXT_UP_LIMIT`のバリデーションが引き続き機能していることを確認(通常のpicker経由の設定フローに影響がないこと)