### PR TITLE
Fix/improve UI/ux

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -155,6 +155,15 @@ body {
     }
 }
 
+select.search-input {
+    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23fff' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/%3e%3c/svg%3e");
+
+    option {
+        background-color: #2A3F5A;
+        color: #fff;
+    }
+}
+
 nav.pagination {
     background-color: transparent;
     display: flex;

--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -5,8 +5,94 @@ nav {
   background-color: #171D25;
 }
 
+footer {
+  background-color: #171D25;
+}
+
 body {
   background-color: #1B2838;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.text-muted-steam {
+    color: #8f98a0;
+}
+
+.btn-steam-share {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 50%;
+    background-color: #2a475e;
+    color: #fff;
+    text-decoration: none;
+
+    &:hover {
+        background-color: #375875;
+        color: #fff;
+    }
+}
+
+.btn-steam-primary {
+    background: linear-gradient(90deg, #67c1f5, #2a6fa8);
+    color: #fff;
+    font-weight: bold;
+    border: none;
+    border-radius: 3px;
+    padding: 0.6rem 1.75rem;
+
+    &:hover {
+        color: #fff;
+        filter: brightness(1.15);
+    }
+}
+
+.btn-steam-search {
+    background-color: #67c1f5;
+    border: none;
+    color: #fff;
+    padding: 0.5rem 0.9rem;
+
+    &:hover {
+        background-color: #4f9fd1;
+        color: #fff;
+    }
+}
+
+.nav-tab-toggle {
+    background: transparent;
+    border: none;
+    color: #fff;
+    padding: 0.5rem 0.25rem;
+
+    &:hover,
+    &:focus,
+    &:active {
+        background: transparent !important;
+        color: #66c0f4 !important;
+    }
+
+    &::after {
+        margin-left: 0.4rem;
+    }
+}
+
+.btn-steam-signin {
+    background: linear-gradient(90deg, #a4d007, #6dab13);
+    color: #fff;
+    font-weight: bold;
+    border: none;
+    border-radius: 3px;
+    padding: 0.6rem 1.75rem;
+
+    &:hover {
+        color: #fff;
+        filter: brightness(1.1);
+    }
 }
 
 .btn-color {
@@ -14,11 +100,11 @@ body {
 }
 
 .card-header-color {
-    background-color: #434950;
+    background-color: #2a475e;
 }
 
 .card-body-color {
-    background-color: #606872;
+    background-color: #16202d;
 }
 
 .task-row-pending {
@@ -68,12 +154,12 @@ nav.pagination {
         display: inline-block;
         padding: 0.35rem 0.75rem;
         border-radius: 0.375rem;
-        background-color: #67707B;
+        background-color: #2a475e;
         color: #fff;
         text-decoration: none;
 
         &:hover {
-            background-color: #7d8791;
+            background-color: #375875;
         }
     }
 
@@ -105,17 +191,16 @@ nav.pagination {
 
 .price-display {
   font-size: 10rem;
+  line-height: 1;
 }
 
 .character-fixed {
-  position: fixed;
-  bottom: 10rem;
-  right: 10rem;
+  flex-shrink: 0;
 }
 
 .character-size{
-  width: 400px;
-  height: 400px;
+  width: 250px;
+  height: 250px;
 }
 
 .speech-bubble {

--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -16,8 +16,26 @@ body {
   flex-direction: column;
 }
 
+.card {
+  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.35);
+}
+
+.link-steam-accent {
+  color: #66c0f4;
+
+  &:hover {
+    color: #8fd3ff;
+  }
+}
+
 .text-muted-steam {
     color: #8f98a0;
+}
+
+.stat-tile {
+    flex: 1 1 0;
+    background: linear-gradient(135deg, #4a5568, #5c6678);
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
 }
 
 .btn-steam-share {
@@ -100,7 +118,7 @@ body {
 }
 
 .card-header-color {
-    background-color: #2a475e;
+    background: linear-gradient(135deg, #2f4f68, #223c50);
 }
 
 .card-body-color {
@@ -192,6 +210,7 @@ nav.pagination {
 .price-display {
   font-size: 10rem;
   line-height: 1;
+  text-shadow: 5px 5px 0 rgba(255, 255, 255, 0.2);
 }
 
 .character-fixed {

--- a/app/controllers/play_focus_controller.rb
+++ b/app/controllers/play_focus_controller.rb
@@ -10,6 +10,7 @@ class PlayFocusController < ApplicationController
     @available_libraries = @available_libraries.where('games.game_title ILIKE ?', "%#{params[:q]}%") if params[:q].present?
     @available_libraries = @available_libraries.cleared if @cleared_filter == 'cleared'
     @available_libraries = @available_libraries.not_cleared if @cleared_filter == 'uncleared'
+    @available_libraries = @available_libraries.page(params[:page])
   end
 
   def set_slot

--- a/app/controllers/play_focus_controller.rb
+++ b/app/controllers/play_focus_controller.rb
@@ -16,6 +16,10 @@ class PlayFocusController < ApplicationController
   def set_slot
     library = current_user.user_game_libraries.find(params[:library_id])
 
+    if params[:slot] == 'next_up'
+      current_user.user_game_libraries.next_up.where.not(id: library.id).update_all(play_focus: :unfocused)
+    end
+
     if library.update(play_focus: params[:slot])
       redirect_to play_focus_path, notice: '設定しました。'
     else

--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -1,12 +1,7 @@
 class StatisticsController < ApplicationController
-  CHART_RANGES = {
-    'week' => 1.week,
-    'month' => 1.month,
-    'half_year' => 6.months,
-    'year' => 1.year,
-    'all' => nil
-  }.freeze
+  CHART_RANGES = %w[week month half_year year all].freeze
   DEFAULT_CHART_RANGE = 'month'
+  CHART_RANGE_OFFSET_OPTIONS_COUNT = 12
 
   def show
     @user = current_user
@@ -29,10 +24,13 @@ class StatisticsController < ApplicationController
     @best_cost_performance_games = cost_performance_ranking[:best]
     @worst_cost_performance_games = cost_performance_ranking[:worst]
 
-    @chart_range = CHART_RANGES.key?(params[:chart_range]) ? params[:chart_range] : DEFAULT_CHART_RANGE
+    @chart_range = CHART_RANGES.include?(params[:chart_range]) ? params[:chart_range] : DEFAULT_CHART_RANGE
+    @chart_range_offset = @chart_range == 'all' ? 0 : params[:chart_range_offset].to_i.clamp(0, CHART_RANGE_OFFSET_OPTIONS_COUNT - 1)
+    @chart_range_options = chart_range_offset_options(@chart_range)
+
     @user_statistic_snapshots = current_user.user_statistic_snapshots.order(:recorded_on)
-    duration = CHART_RANGES[@chart_range]
-    @user_statistic_snapshots = @user_statistic_snapshots.where(recorded_on: duration.ago..) if duration
+    start_date, end_date = chart_range_period(@chart_range, @chart_range_offset)
+    @user_statistic_snapshots = @user_statistic_snapshots.where(recorded_on: start_date..end_date) if start_date
   end
 
   def cost_performance_detailed_ranking
@@ -58,5 +56,50 @@ class StatisticsController < ApplicationController
 
   rescue #update!で例外エラーが発生したときの処理 beginが省略されている rescue単体にendは不要
     redirect_to statistic_path, alert: 'クリア済みゲームの更新に失敗しました。'
+  end
+
+  private
+
+  def chart_range_period(range, offset)
+    today = Date.current
+    case range
+    when 'week'
+      start_date = today.beginning_of_week - offset.weeks
+      [start_date, start_date.end_of_week]
+    when 'month'
+      start_date = today.beginning_of_month - offset.months
+      [start_date, start_date.end_of_month]
+    when 'half_year'
+      current_half_start = today.month <= 6 ? today.beginning_of_year : today.beginning_of_year + 6.months
+      start_date = current_half_start - (offset * 6).months
+      [start_date, start_date + 6.months - 1.day]
+    when 'year'
+      start_date = today.beginning_of_year - offset.years
+      [start_date, start_date.end_of_year]
+    else
+      [nil, nil]
+    end
+  end
+
+  def chart_range_offset_options(range)
+    return [] if range == 'all'
+
+    (0...CHART_RANGE_OFFSET_OPTIONS_COUNT).map do |offset|
+      start_date, end_date = chart_range_period(range, offset)
+      [chart_range_period_label(range, start_date, end_date), offset]
+    end
+  end
+
+  def chart_range_period_label(range, start_date, end_date)
+    case range
+    when 'week'
+      "#{start_date.strftime('%-m/%-d')}〜#{end_date.strftime('%-m/%-d')}"
+    when 'month'
+      "#{start_date.year}年#{start_date.month}月"
+    when 'half_year'
+      "#{start_date.year}年#{start_date.month <= 6 ? '上半期' : '下半期'}"
+    when 'year'
+      "#{start_date.year}年"
+    end
   end
 end

--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -10,6 +10,7 @@ class StatisticsController < ApplicationController
     @total_games_count = current_user.user_game_libraries.count
     @unplayed_rate = UserGameLibrary.unplayed_rate(current_user)
     @recommended_games = current_user.user_game_libraries.unplayed.cheapest_games.recommend_3
+    @next_up_library = current_user.user_game_libraries.next_up.first
     @cleared_after_unplayed_games = current_user.user_game_libraries.cleared_after_unplayed.includes(:game)
 
     @cleared_game_count_rate = UserGameLibrary.cleared_game_count_rate(current_user)

--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -7,6 +7,7 @@ class StatisticsController < ApplicationController
     @user = current_user
     @total_price = UserGameLibrary.total_price(current_user)
     @unplayed_games = current_user.user_game_libraries.unplayed.includes(:game)# .limit(UserGameLibrary::TSUMIGE_LIST_LIMIT)
+    @no_backlog = @unplayed_games.empty?
     @total_games_count = current_user.user_game_libraries.count
     @unplayed_rate = UserGameLibrary.unplayed_rate(current_user)
     @recommended_games = current_user.user_game_libraries.unplayed.cheapest_games.recommend_3
@@ -19,6 +20,9 @@ class StatisticsController < ApplicationController
     min_count = game_genres.map{ |x| x[1] }.min
     @most_unplayed_game_genres = game_genres.select{ |x| x[1] == max_count }
     @least_unplayed_game_genres = game_genres.select{ |x| x[1] == min_count }
+    @genre_example_games = (@most_unplayed_game_genres + @least_unplayed_game_genres).each_with_object({}) do |(genre_name, _count), hash|
+      hash[genre_name] = current_user.user_game_libraries.unplayed.joins(game: :game_genre_types).find_by(game_genre_types: { name: genre_name })&.game
+    end
 
     cost_performance_ranking = UserGameLibrary.cost_performance_ranking(current_user)
     @best_cost_performance_games = cost_performance_ranking[:best]

--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -3,6 +3,8 @@ class StatisticsController < ApplicationController
     @user = current_user
     @total_price = UserGameLibrary.total_price(current_user)
     @unplayed_games = current_user.user_game_libraries.unplayed.includes(:game)# .limit(UserGameLibrary::TSUMIGE_LIST_LIMIT)
+    @total_games_count = current_user.user_game_libraries.count
+    @unplayed_rate = UserGameLibrary.unplayed_rate(current_user)
     @recommended_games = current_user.user_game_libraries.unplayed.cheapest_games.recommend_3
     @cleared_after_unplayed_games = current_user.user_game_libraries.cleared_after_unplayed.includes(:game)
 

--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -31,6 +31,7 @@ class StatisticsController < ApplicationController
     @user_statistic_snapshots = current_user.user_statistic_snapshots.order(:recorded_on)
     start_date, end_date = chart_range_period(@chart_range, @chart_range_offset)
     @user_statistic_snapshots = @user_statistic_snapshots.where(recorded_on: start_date..end_date) if start_date
+    @chart_labels, @chart_prices, @chart_rates = chart_series(@user_statistic_snapshots, start_date, end_date)
   end
 
   def cost_performance_detailed_ranking
@@ -59,6 +60,16 @@ class StatisticsController < ApplicationController
   end
 
   private
+
+  def chart_series(snapshots, start_date, end_date)
+    return [snapshots.pluck(:recorded_on), snapshots.pluck(:total_price), snapshots.pluck(:unplayed_rate)] unless start_date
+
+    snapshots_by_date = snapshots.index_by(&:recorded_on)
+    dates = (start_date..end_date).to_a
+    prices = dates.map { |date| snapshots_by_date[date]&.total_price }
+    rates = dates.map { |date| snapshots_by_date[date]&.unplayed_rate }
+    [dates, prices, rates]
+  end
 
   def chart_range_period(range, offset)
     today = Date.current

--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -1,4 +1,13 @@
 class StatisticsController < ApplicationController
+  CHART_RANGES = {
+    'week' => 1.week,
+    'month' => 1.month,
+    'half_year' => 6.months,
+    'year' => 1.year,
+    'all' => nil
+  }.freeze
+  DEFAULT_CHART_RANGE = 'month'
+
   def show
     @user = current_user
     @total_price = UserGameLibrary.total_price(current_user)
@@ -20,7 +29,10 @@ class StatisticsController < ApplicationController
     @best_cost_performance_games = cost_performance_ranking[:best]
     @worst_cost_performance_games = cost_performance_ranking[:worst]
 
+    @chart_range = CHART_RANGES.key?(params[:chart_range]) ? params[:chart_range] : DEFAULT_CHART_RANGE
     @user_statistic_snapshots = current_user.user_statistic_snapshots.order(:recorded_on)
+    duration = CHART_RANGES[@chart_range]
+    @user_statistic_snapshots = @user_statistic_snapshots.where(recorded_on: duration.ago..) if duration
   end
 
   def cost_performance_detailed_ranking

--- a/app/javascript/controllers/snapshot_chart_controller.js
+++ b/app/javascript/controllers/snapshot_chart_controller.js
@@ -16,14 +16,16 @@ export default class extends Controller {
             data: this.pricesValue,
             borderColor: "#325C80",
             backgroundColor: "#325C80",
-            yAxisID: "y"
+            yAxisID: "y",
+            spanGaps: true
           },
           {
             label: "積み率(%)",
             data: this.ratesValue,
             borderColor: "#D6D9DC",
             backgroundColor: "#D6D9DC",
-            yAxisID: "y1"
+            yAxisID: "y1",
+            spanGaps: true
           }
         ]
       },

--- a/app/views/games/index.html.slim
+++ b/app/views/games/index.html.slim
@@ -2,11 +2,11 @@ div.card.text-white.w-50.border-0.mx-auto.mt-5
   div.card-header.card-header-color.pb-0
     p.p-1 ゲーム一覧
   div.d-flex.gap-3.px-3.pb-2.card-header-color
-    = link_to '名前順', games_path(sort: 'name'), class: 'text-white'
-    = link_to '価格の安い順', games_path(sort: 'price_asc'), class: 'text-white'
-    = link_to '価格の高い順', games_path(sort: 'price_desc'), class: 'text-white'
-    = link_to '積み率順', games_path(sort: 'unplayed_rate'), class: 'text-white'
-    = link_to '所持者数順', games_path(sort: 'possessed_count'), class: 'text-white'
+    = link_to '名前順', games_path(sort: 'name'), class: 'link-steam-accent'
+    = link_to '価格の安い順', games_path(sort: 'price_asc'), class: 'link-steam-accent'
+    = link_to '価格の高い順', games_path(sort: 'price_desc'), class: 'link-steam-accent'
+    = link_to '積み率順', games_path(sort: 'unplayed_rate'), class: 'link-steam-accent'
+    = link_to '所持者数順', games_path(sort: 'possessed_count'), class: 'link-steam-accent'
   div.d-flex.justify-content-between.px-3.card-header-color
     span.col-3 ゲームタイトル
     span.col-2 所持者数
@@ -16,7 +16,7 @@ div.card.text-white.w-50.border-0.mx-auto.mt-5
     ol.w-100.px-3
       - @games.each do |game|
         li.d-flex.justify-content-between.align-items-center.mt-3
-          span.col-3 = link_to game.game_title, game_path(game)
+          span.col-3 = link_to game.game_title, game_path(game), class: 'link-steam-accent'
           span.col-2 = "#{@all_games_count.fetch(game.id, 0)}人"
           span.col-2 = "#{((@all_unplayed_games_count.fetch(game.id, 0).to_f / @all_games_count.fetch(game.id, 0).to_f) * 100).round(1)}%"
           span.col-5 = image_tag steam_thumbnail_image(game), class: 'img-fluid', onerror: "this.onerror=null;this.src='#{broken_thumbnail_placeholder}'"

--- a/app/views/layouts/_footer.slim
+++ b/app/views/layouts/_footer.slim
@@ -1,4 +1,4 @@
 footer.text-center.py-3.mt-5
   = link_to '利用規約', terms_path, class: 'text-white me-3'
   = link_to 'プライバシーポリシー', privacy_policy_path, class: 'text-white me-3'
-  = link_to 'お問い合わせ', new_contact_path, class: 'text-white'
+  = link_to 'お問い合わせ', new_contact_path, class: 'link-steam-accent'

--- a/app/views/layouts/_header.slim
+++ b/app/views/layouts/_header.slim
@@ -6,7 +6,7 @@ nav.navbar.navbar-expand-lg.ps-3.fixed-top
   - if user_signed_in?
     div.ms-auto.d-flex
       div.dropdown.pe-3
-        button.btn.btn-secondary.dropdown-toggle.text-white.me-3 type="button" data-bs-toggle="dropdown" aria-expanded="false" 積みゲー分析
+        button.nav-tab-toggle.dropdown-toggle.me-3 type="button" data-bs-toggle="dropdown" aria-expanded="false" 積みゲー分析
         ul.dropdown-menu
           li
             = link_to '積みゲー総額', user_path, class: 'dropdown-item'
@@ -15,7 +15,7 @@ nav.navbar.navbar-expand-lg.ps-3.fixed-top
             = link_to 'プレイ状況', play_focus_path, class: 'dropdown-item'
 
       div.dropdown.pe-3
-        button.btn.btn-secondary.dropdown-toggle.text-white.me-3 type="button" data-bs-toggle="dropdown" aria-expanded="false" 積みゲーマイレージ
+        button.nav-tab-toggle.dropdown-toggle.me-3 type="button" data-bs-toggle="dropdown" aria-expanded="false" 積みゲーマイレージ
         ul.dropdown-menu
           li
             = link_to '育成', '#', class: 'dropdown-item'
@@ -23,7 +23,7 @@ nav.navbar.navbar-expand-lg.ps-3.fixed-top
             = link_to 'マイレージ確認', tasks_path, class: 'dropdown-item'
 
       div.dropdown.pe-3
-        button.btn.btn-secondary.dropdown-toggle.text-white type="button" data-bs-toggle="dropdown" aria-expanded="false" #{current_user.name}
+        button.nav-tab-toggle.dropdown-toggle type="button" data-bs-toggle="dropdown" aria-expanded="false" #{current_user.name}
         ul.dropdown-menu
           li
             - if @now_playing_libraries.present?
@@ -36,6 +36,7 @@ nav.navbar.navbar-expand-lg.ps-3.fixed-top
 
       div.position-relative data-controller="search" data-search-url-value=search_suggestions_games_path
         = search_form_for @q, html: { class: "d-flex align-items-center" } do |f|
-          = f.search_field :game_title_cont, data: { action: "input->search#search focus->search#search" }, class: "search-input rounded me-2", placeholder: "ゲームを検索", autocomplete: "off"
-          = f.submit "検索", class: "btn btn-color text-white"
+          = f.search_field :game_title_cont, data: { action: "input->search#search focus->search#search" }, class: "search-input form-control rounded me-2", placeholder: "ゲームを検索", autocomplete: "off"
+          = f.button type: "submit", class: "btn btn-steam-search" do
+            i.bi.bi-search
         = turbo_frame_tag "search_suggestions", data: { search_target: "frame" }, class: "position-absolute top-100 end-0 mt-1", style: "z-index: 1050; width: 350px;"

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,7 +24,9 @@
     <% flash.each do |type, message| %>
       <div class="alert alert-<%= type %>"><%= message %></div>
     <% end %>
-    <%= yield %>
+    <main class="flex-grow-1">
+      <%= yield %>
+    </main>
     <%= render "layouts/footer" %>
   </body>
 </html>

--- a/app/views/play_focus/picker.html.slim
+++ b/app/views/play_focus/picker.html.slim
@@ -2,9 +2,9 @@ div.card.text-white.w-50.border-0.mx-auto.mt-5 data-controller="search" data-sea
   div.card-header.card-header-color.pb-0
     p.p-1 ゲームを選択
   div.d-flex.gap-3.px-3.pb-2.card-header-color
-    = link_to 'すべて', picker_play_focus_path(slot: @slot, q: params[:q]), class: 'text-white'
-    = link_to '未クリア', picker_play_focus_path(slot: @slot, q: params[:q], cleared: 'uncleared'), class: 'text-white'
-    = link_to 'クリア済み', picker_play_focus_path(slot: @slot, q: params[:q], cleared: 'cleared'), class: 'text-white'
+    = link_to 'すべて', picker_play_focus_path(slot: @slot, q: params[:q]), class: 'link-steam-accent'
+    = link_to '未クリア', picker_play_focus_path(slot: @slot, q: params[:q], cleared: 'uncleared'), class: 'link-steam-accent'
+    = link_to 'クリア済み', picker_play_focus_path(slot: @slot, q: params[:q], cleared: 'cleared'), class: 'link-steam-accent'
 
   div.card-body.card-body-color
     = form_with url: picker_play_focus_path, method: :get, class: "d-flex align-items-center mb-3" do |f|

--- a/app/views/play_focus/picker.html.slim
+++ b/app/views/play_focus/picker.html.slim
@@ -28,5 +28,6 @@ div.card.text-white.w-50.border-0.mx-auto.mt-5 data-controller="search" data-sea
               = button_to "未クリアに戻す", revert_cleared_games_play_focus_path(library_id: library.id), method: :patch, class: "btn btn-secondary text-white btn-sm ms-2"
             - else
               = button_to "クリアにする", update_cleared_games_play_focus_path(library_id: library.id), method: :patch, class: "btn btn-secondary text-white btn-sm ms-2"
+      = paginate @available_libraries
 
     = link_to "戻る", play_focus_path, class: "btn btn-secondary text-white mt-3"

--- a/app/views/static_pages/top.html.slim
+++ b/app/views/static_pages/top.html.slim
@@ -1,15 +1,20 @@
-div.container style="margin-top: 10rem;"
-    h1.text-center.pt-3.pb-3 積みゲー総額を見てみよう！
+div.container style="margin-top: 4rem;"
+    h1.text-center.pt-3.pb-1 積みゲー総額を見てみよう！
 
-    div.text-center.pb-4
-        =  button_to 'Steamアカウントでログイン', user_steam_omniauth_authorize_path, method: :post, class: "btn btn-color text-white", data: { turbo: false }
+    p.text-center.pb-3 Steamアカウントでログインするだけで、あなたの積みゲーを自動で可視化します。
 
-    h2.text-center.pb-3 積みゲー金額ランキング
+    div.text-center.pb-5
+        =  button_to 'Steamアカウントでログイン', user_steam_omniauth_authorize_path, method: :post, class: "btn btn-steam-signin", data: { turbo: false }
 
-    div.d-flex.justify-content-center.pb-5
-        ol
-            - @unplayed_price_and_count_ranking_users.each do |user_price_count|
-                li = "¥#{user_price_count[1]} (#{user_price_count[2]}本)"
+    div.card.text-white.w-75.border-0.mx-auto.mb-5
+        div.card-header.card-header-color.pb-0
+            p.p-1
+                i.bi.bi-trophy-fill.me-2
+                | 積みゲー金額ランキング
+        div.card-body.card-body-color
+            ol.w-100.px-3.mb-0
+                - @unplayed_price_and_count_ranking_users.each do |user_price_count|
+                    li = "¥#{user_price_count[1]} (#{user_price_count[2]}本)"
 
     div.card.text-white.w-75.border-0.mx-auto.mb-5
         div.card-header.card-header-color.pb-0
@@ -19,17 +24,17 @@ div.container style="margin-top: 10rem;"
         div.card-body.card-body-color
             p.mb-4 積み算は、Steamの積みゲー（未プレイ・未クリアのゲーム）を楽しく消化するためのWebサービスです。
             div.d-flex.gap-3.flex-wrap.justify-content-center
-                div.p-3.rounded.text-center style="background-color: #434950; flex: 1 1 220px;"
+                div.p-3.rounded.text-center style="background-color: #2a475e; flex: 1 1 220px;"
                     p.mb-2
                         i.bi.bi-bar-chart-fill.me-2
                         strong 積みゲー可視化
                     p.small.mb-0 Steamの積みゲーを総額・積み率・推移グラフで把握できます。
-                div.p-3.rounded.text-center style="background-color: #434950; flex: 1 1 220px;"
+                div.p-3.rounded.text-center style="background-color: #2a475e; flex: 1 1 220px;"
                     p.mb-2
                         i.bi.bi-people-fill.me-2
                         strong 他ユーザーとの比較
                     p.small.mb-0 自分の積みゲー状況を、他のユーザーの平均と比較できます。
-                div.p-3.rounded.text-center style="background-color: #434950; flex: 1 1 220px;"
+                div.p-3.rounded.text-center style="background-color: #2a475e; flex: 1 1 220px;"
                     p.mb-2
                         i.bi.bi-chat-heart-fill.me-2
                         strong キャラと一緒に
@@ -44,6 +49,9 @@ div.container style="margin-top: 10rem;"
             details.mb-3
                 summary.fw-bold ログイン情報は安全ですか？
                 p.small.mt-2.mb-0 ログインにはSteam公式のOpenID認証を使用しており、パスワードなどの認証情報は一切保存していません。
+            details.mb-3
+                summary.fw-bold ログインしてもゲームが同期されません
+                p.small.mt-2.mb-0 Steamのプロフィール設定で「ゲームの詳細」のプライバシー設定が非公開になっていると、ゲームの所有情報・プレイ時間を取得できません。Steamコミュニティのプライバシー設定から「公開」に変更してから、再度お試しください。
             details.mb-3
                 summary.fw-bold 積みゲー総額が表示されないのはなぜですか？
                 p.small.mt-2.mb-0 初回ログイン時は価格取得まで時間がかかる場合がございます。反映まで少し待ってから再読み込みしてみてください。

--- a/app/views/statistics/show.html.slim
+++ b/app/views/statistics/show.html.slim
@@ -38,6 +38,9 @@ div.mx-auto.mt-5 style="max-width: 960px;"
       p.p-1.fs-4.mb-0
         i.bi.bi-graph-up.me-2
         | 積みゲー推移
+    div.d-flex.gap-3.px-3.pb-2.card-header-color
+      - [['1週間', 'week'], ['1か月', 'month'], ['半年', 'half_year'], ['1年', 'year'], ['全期間', 'all']].each do |label, key|
+        = link_to label, statistic_path(chart_range: key), class: key == @chart_range ? 'text-white fw-bold' : 'link-steam-accent'
     div.card-body.card-body-color.p-4
       div.rounded.p-3 style="background-color: #8b929b; box-shadow: 0 6px 14px rgba(0, 0, 0, 0.35);"
         canvas data-snapshot-chart-target="canvas"

--- a/app/views/statistics/show.html.slim
+++ b/app/views/statistics/show.html.slim
@@ -46,8 +46,10 @@ div.mx-auto.mt-5 style="max-width: 960px;"
   div.row.g-5.mb-5
     div.col-lg-6
       div.card.text-white.border-0.h-100
-        div.card-header.card-header-color.pb-0
-          p.p-1 ネクストプレイ提案
+        div.card-header.card-header-color.py-3
+          p.p-1.fs-4.mb-0
+            i.bi.bi-play-circle-fill.me-2
+            | ネクストプレイ提案
         div.d-flex.justify-content-between.px-3.card-header-color
           span ゲームタイトル
           span 最終プレイ日
@@ -63,8 +65,10 @@ div.mx-auto.mt-5 style="max-width: 960px;"
 
     div.col-lg-6
       div.card.text-white.border-0.h-100
-        div.card-header.card-header-color.pb-0
-          p.p-1 逆レコメンド
+        div.card-header.card-header-color.py-3
+          p.p-1.fs-4.mb-0
+            i.bi.bi-lightbulb-fill.me-2
+            | 逆レコメンド
         div.card-body.card-body-color
           - @most_unplayed_game_genres.each do |genre|
             p.mb-1 一番詰んでるゲームジャンルは#{genre[0]}で、#{genre[1]}個積んでるよ～
@@ -78,8 +82,10 @@ div.mx-auto.mt-5 style="max-width: 960px;"
   div.row.g-5.mb-5
     div.col-lg-6
       div.card.text-white.border-0.h-100
-        div.card-header.card-header-color.pb-0
-          span.p-1 積みゲーリスト
+        div.card-header.card-header-color.py-3
+          p.p-1.fs-4.mb-0
+            i.bi.bi-hourglass-split.me-2
+            | 積みゲーリスト
         div.d-flex.justify-content-between.px-3.card-header-color
           span.col-6 ゲームタイトル
           span.col-5 プレイ時間
@@ -96,8 +102,10 @@ div.mx-auto.mt-5 style="max-width: 960px;"
 
     div.col-lg-6
       div.card.text-white.border-0.h-100
-        div.card-header.card-header-color.pb-0
-          p.p-1 一度積んでからクリアしたゲーム一覧
+        div.card-header.card-header-color.py-3
+          p.p-1.fs-4.mb-0
+            i.bi.bi-award-fill.me-2
+            | 一度積んでからクリアしたゲーム一覧
         div.card-body.card-body-color
           ol.w-100.px-3
             - @cleared_after_unplayed_games.each do |library|
@@ -107,8 +115,10 @@ div.mx-auto.mt-5 style="max-width: 960px;"
                 span.col-6 = "#{(library.cleared_date - library.unplayed_date).to_i}日"
 
   div.card.text-white.border-0.mb-5
-    div.card-header.card-header-color.pb-0
-      p.p-1 コスパランキング
+    div.card-header.card-header-color.py-3
+      p.p-1.fs-4.mb-0
+        i.bi.bi-bar-chart-line-fill.me-2
+        | コスパランキング
     div.card-body.card-body-color
       ol.w-100.px-3
         - @best_cost_performance_games.each do |library|

--- a/app/views/statistics/show.html.slim
+++ b/app/views/statistics/show.html.slim
@@ -12,7 +12,7 @@ div.card.text-white.w-50.border-0.mx-auto.mt-5 data-controller="snapshot-chart" 
   div.card-header.card-header-color.pb-0
     p.p-1 積みゲー推移
   div.card-body.card-body-color
-    div.rounded.p-2 style="background-color: #7d8791;"
+    div.rounded.p-2 style="background-color: #8b929b;"
       canvas data-snapshot-chart-target="canvas"
 
 div.card.text-white.w-50.border-0.mx-auto.mt-5

--- a/app/views/statistics/show.html.slim
+++ b/app/views/statistics/show.html.slim
@@ -1,92 +1,126 @@
 = turbo_stream_from current_user
 
-div.card.text-white.w-50.border-0.mx-auto.mt-5
-  div.card-header.card-header-color.pb-0
-    p.p-1 #{@user.name}
-  div.card-body.card-body-color.d-flex
-    p.me-4 積みゲー総額: #{render "user_game_libraries/total_price", total_price: @total_price, user: @user}
-    p.me-4 積みゲー本数: #{@unplayed_games.count}
-    p.me-4 全体消化率: #{@cleared_game_count_rate.round(2)}%
+div.mx-auto.mt-5 style="max-width: 960px;"
+  div.card.text-white.border-0.mb-5
+    div.card-header.card-header-color.py-3
+      p.p-1.fs-4.mb-0
+        i.bi.bi-person-circle.me-2
+        | #{@user.name} さんの積みゲー統計
+    div.card-body.card-body-color.d-flex.flex-wrap.gap-3
+      div.text-center.p-3.rounded.stat-tile
+        div.small.text-muted-steam
+          i.bi.bi-currency-yen.me-1
+          | 積みゲー総額
+        div.fs-4.fw-bold = render "user_game_libraries/total_price", total_price: @total_price, user: @user
+      div.text-center.p-3.rounded.stat-tile
+        div.small.text-muted-steam
+          i.bi.bi-controller.me-1
+          | 総本数
+        div.fs-4.fw-bold = @total_games_count
+      div.text-center.p-3.rounded.stat-tile
+        div.small.text-muted-steam
+          i.bi.bi-hourglass-split.me-1
+          | 積みゲー本数
+        div.fs-4.fw-bold = @unplayed_games.count
+      div.text-center.p-3.rounded.stat-tile
+        div.small.text-muted-steam
+          i.bi.bi-pie-chart-fill.me-1
+          | 積みゲー率
+        div.fs-4.fw-bold = "#{@unplayed_rate.round(1)}%"
+      div.text-center.p-3.rounded.stat-tile
+        div.small.text-muted-steam
+          i.bi.bi-check2-circle.me-1
+          | 全体消化率
+        div.fs-4.fw-bold = "#{@cleared_game_count_rate.round(2)}%"
 
-div.card.text-white.w-50.border-0.mx-auto.mt-5 data-controller="snapshot-chart" data-snapshot-chart-labels-value="#{@user_statistic_snapshots.pluck(:recorded_on).to_json}" data-snapshot-chart-prices-value="#{@user_statistic_snapshots.pluck(:total_price).to_json}" data-snapshot-chart-rates-value="#{@user_statistic_snapshots.pluck(:unplayed_rate).to_json}"
-  div.card-header.card-header-color.pb-0
-    p.p-1 積みゲー推移
-  div.card-body.card-body-color
-    div.rounded.p-2 style="background-color: #8b929b;"
-      canvas data-snapshot-chart-target="canvas"
+  div.card.text-white.border-0.mb-5 data-controller="snapshot-chart" data-snapshot-chart-labels-value="#{@user_statistic_snapshots.pluck(:recorded_on).to_json}" data-snapshot-chart-prices-value="#{@user_statistic_snapshots.pluck(:total_price).to_json}" data-snapshot-chart-rates-value="#{@user_statistic_snapshots.pluck(:unplayed_rate).to_json}"
+    div.card-header.card-header-color.py-3
+      p.p-1.fs-4.mb-0
+        i.bi.bi-graph-up.me-2
+        | 積みゲー推移
+    div.card-body.card-body-color.p-4
+      div.rounded.p-3 style="background-color: #8b929b; box-shadow: 0 6px 14px rgba(0, 0, 0, 0.35);"
+        canvas data-snapshot-chart-target="canvas"
+      p.small.text-muted-steam.mt-2.mb-0 ※1日1度サイトへアクセス時に積みゲー総額と積みゲー率が記録されます。アクセスがなかった日は記録されません。
 
-div.card.text-white.w-50.border-0.mx-auto.mt-5
-  div.card-header.card-header-color.pb-0
-    p.p-1 ネクストプレイ提案
-  div.d-flex.justify-content-between.px-3.card-header-color
-    span ゲームタイトル
-    span 最終プレイ日
-  div.card-body.card-body-color.d-flex
-    ol.w-100.px-3
-      - @recommended_games.each do |library|
-        li.d-flex.justify-content-between
-          span = link_to library.game.game_title, game_path(library.game), class: 'text-white'
-          - if library.last_played_at
-            span = library.last_played_at&.strftime('%Y年%m月%d日')
-          - else
-            span 未プレイ
+  div.row.g-5.mb-5
+    div.col-lg-6
+      div.card.text-white.border-0.h-100
+        div.card-header.card-header-color.pb-0
+          p.p-1 ネクストプレイ提案
+        div.d-flex.justify-content-between.px-3.card-header-color
+          span ゲームタイトル
+          span 最終プレイ日
+        div.card-body.card-body-color
+          ol.w-100.px-3
+            - @recommended_games.each do |library|
+              li.d-flex.justify-content-between
+                span = link_to library.game.game_title, game_path(library.game), class: 'link-steam-accent'
+                - if library.last_played_at
+                  span = library.last_played_at&.strftime('%Y年%m月%d日')
+                - else
+                  span 未プレイ
 
-div.card.text-white.w-50.border-0.mx-auto.mt-5
-  div.card-header.card-header-color.pb-0
-    p.p-1 逆レコメンド
-  div.card-body.card-body-color.d-flex
-    - @most_unplayed_game_genres.each do |genre|
-      p.me-4 一番詰んでるゲームジャンルは#{genre[0]}で、#{genre[1]}個積んでるよ～
-      p.me-4
-        = link_to "#{genre[0]}ゲームを探す", steam_genre_name_search(genre[0]), target: :_blank, rel: "noopener noreferrer"
-    - @least_unplayed_game_genres.each do |genre|
-      p.me-4 一番詰んでないゲームジャンルは#{genre[0]}で、#{genre[1]}個積んでるよ～
-      p.me-4
-        = link_to "#{genre[0]}ゲームを探す", steam_genre_name_search(genre[0]), target: :_blank, rel: "noopener noreferrer"
+    div.col-lg-6
+      div.card.text-white.border-0.h-100
+        div.card-header.card-header-color.pb-0
+          p.p-1 逆レコメンド
+        div.card-body.card-body-color
+          - @most_unplayed_game_genres.each do |genre|
+            p.mb-1 一番詰んでるゲームジャンルは#{genre[0]}で、#{genre[1]}個積んでるよ～
+            p.mb-3
+              = link_to "#{genre[0]}ゲームを探す", steam_genre_name_search(genre[0]), target: :_blank, rel: "noopener noreferrer"
+          - @least_unplayed_game_genres.each do |genre|
+            p.mb-1 一番詰んでないゲームジャンルは#{genre[0]}で、#{genre[1]}個積んでるよ～
+            p.mb-0
+              = link_to "#{genre[0]}ゲームを探す", steam_genre_name_search(genre[0]), target: :_blank, rel: "noopener noreferrer"
 
-div.card.text-white.w-50.border-0.mx-auto.mt-5
-  div.card-header.card-header-color.pb-0
-    span.p-1 積みゲーリスト
-  div.d-flex.justify-content-between.px-3.card-header-color
-    span.col-6 ゲームタイトル
-    span.col-5 プレイ時間
-    span.col-3 クリア
-  div.card-body.card-body-color.d-flex
-    = form_with url: update_cleared_games_statistic_path, method: :patch do |f|
+  div.row.g-5.mb-5
+    div.col-lg-6
+      div.card.text-white.border-0.h-100
+        div.card-header.card-header-color.pb-0
+          span.p-1 積みゲーリスト
+        div.d-flex.justify-content-between.px-3.card-header-color
+          span.col-6 ゲームタイトル
+          span.col-5 プレイ時間
+          span.col-3 クリア
+        div.card-body.card-body-color
+          = form_with url: update_cleared_games_statistic_path, method: :patch do |f|
+            ol.w-100.px-3
+              - @unplayed_games.each do |library|
+                li.d-flex.justify-content-between
+                  span.col-6 = link_to library.game.game_title, game_path(library.game), class: 'link-steam-accent'
+                  span.col-6 = "#{(library.minutes_played/60.0).round(1)}時間"
+                  span.col-6 = check_box_tag "cleared_game_ids[]", library.id
+            = f.submit "更新する"
+
+    div.col-lg-6
+      div.card.text-white.border-0.h-100
+        div.card-header.card-header-color.pb-0
+          p.p-1 一度積んでからクリアしたゲーム一覧
+        div.card-body.card-body-color
+          ol.w-100.px-3
+            - @cleared_after_unplayed_games.each do |library|
+              li.d-flex.justify-content-between
+                span.col-6 = link_to library.game.game_title, game_path(library.game), class: 'link-steam-accent'
+                span.col-6 = "#{(library.minutes_played/60.0).round(1)}時間"
+                span.col-6 = "#{(library.cleared_date - library.unplayed_date).to_i}日"
+
+  div.card.text-white.border-0.mb-5
+    div.card-header.card-header-color.pb-0
+      p.p-1 コスパランキング
+    div.card-body.card-body-color
       ol.w-100.px-3
-        - @unplayed_games.each do |library|
+        - @best_cost_performance_games.each do |library|
           li.d-flex.justify-content-between
-            span.col-6 = link_to library.game.game_title, game_path(library.game), class: 'text-white'
+            span.col-6 = link_to library.game.game_title, game_path(library.game), class: 'link-steam-accent'
+            span.col-6 = "¥#{library.game.price}"
             span.col-6 = "#{(library.minutes_played/60.0).round(1)}時間"
-            span.col-6 = check_box_tag "cleared_game_ids[]", library.id
-      = f.submit "更新する"
-
-div.card.text-white.w-50.border-0.mx-auto.mt-5
-  div.card-header.card-header-color.pb-0
-    p.p-1 一度積んでからクリアしたゲーム一覧
-  div.card-body.card-body-color.d-flex
-    ol.w-100.px-3
-      - @cleared_after_unplayed_games.each do |library|
-        li.d-flex.justify-content-between
-          span.col-6 = link_to library.game.game_title, game_path(library.game), class: 'text-white'
-          span.col-6 = "#{(library.minutes_played/60.0).round(1)}時間"
-          span.col-6 = "#{(library.cleared_date - library.unplayed_date).to_i}日"
-
-div.card.text-white.w-50.border-0.mx-auto.mt-5
-  div.card-header.card-header-color.pb-0
-    p.p-1 コスパランキング
-  div.card-body.card-body-color.d-flex
-    ol.w-100.px-3
-      - @best_cost_performance_games.each do |library|
-        li.d-flex.justify-content-between
-          span.col-6 = link_to library.game.game_title, game_path(library.game), class: 'text-white'
-          span.col-6 = "¥#{library.game.price}"
-          span.col-6 = "#{(library.minutes_played/60.0).round(1)}時間"
-          span.col-6 = "#{(((library.minutes_played + 1).to_f / library.game.price)*1000).round(2)}"
-      - @worst_cost_performance_games.each do |library|
-        li.d-flex.justify-content-between
-          span.col-6 = link_to library.game.game_title, game_path(library.game), class: 'text-white'
-          span.col-6 = "¥#{library.game.price}"
-          span.col-6 = "#{(library.minutes_played/60.0).round(1)}時間"
-          span.col-6 = "#{(((library.minutes_played + 1).to_f / library.game.price)*1000).round(2)}"
-      = link_to '詳細へ', cost_performance_detailed_ranking_statistic_path, class: 'btn btn-secondary text-white'
+            span.col-6 = "#{(((library.minutes_played + 1).to_f / library.game.price)*1000).round(2)}"
+        - @worst_cost_performance_games.each do |library|
+          li.d-flex.justify-content-between
+            span.col-6 = link_to library.game.game_title, game_path(library.game), class: 'link-steam-accent'
+            span.col-6 = "¥#{library.game.price}"
+            span.col-6 = "#{(library.minutes_played/60.0).round(1)}時間"
+            span.col-6 = "#{(((library.minutes_played + 1).to_f / library.game.price)*1000).round(2)}"
+        = link_to '詳細へ', cost_performance_detailed_ranking_statistic_path, class: 'btn btn-secondary text-white'

--- a/app/views/statistics/show.html.slim
+++ b/app/views/statistics/show.html.slim
@@ -61,11 +61,18 @@ div.mx-auto.mt-5 style="max-width: 960px;"
         div.card-body.card-body-color.d-flex.flex-column.gap-3
           - @recommended_games.each do |library|
             div.p-3.rounded.stat-tile.d-flex.justify-content-between.align-items-center
-              = link_to library.game.game_title, game_path(library.game), class: 'link-steam-accent fs-5 fw-bold'
-              - if library.last_played_at
-                span.text-muted-steam = library.last_played_at&.strftime('%Y年%m月%d日')
+              div
+                = link_to library.game.game_title, game_path(library.game), class: 'link-steam-accent fs-5 fw-bold'
+                - if library.last_played_at
+                  div.text-muted-steam = library.last_played_at&.strftime('%Y年%m月%d日')
+                - else
+                  div.text-muted-steam 未プレイ
+              - if library.next_up?
+                div.d-flex.align-items-center.gap-2
+                  span.small.text-muted-steam 設定中
+                  = button_to "取り下げる", clear_slot_play_focus_path(library_id: library.id), method: :patch, class: "btn btn-secondary text-white btn-sm"
               - else
-                span.text-muted-steam 未プレイ
+                = button_to "次にプレイに設定", set_slot_play_focus_path(library_id: library.id, slot: 'next_up'), method: :patch, class: "btn btn-color text-white btn-sm", form: { data: { turbo_confirm: (@next_up_library ? "「#{@next_up_library.game.game_title}」から「#{library.game.game_title}」に変更しますか?" : nil) } }
 
     div.col-lg-6
       div.card.text-white.border-0.h-100

--- a/app/views/statistics/show.html.slim
+++ b/app/views/statistics/show.html.slim
@@ -60,12 +60,15 @@ div.mx-auto.mt-5 style="max-width: 960px;"
             | ネクストプレイ提案
         div.card-body.card-body-color.d-flex.flex-column.gap-3
           - @recommended_games.each do |library|
-            div.p-3.rounded.stat-tile.d-flex.justify-content-between.align-items-center
-              = link_to library.game.game_title, game_path(library.game), class: 'link-steam-accent fs-5 fw-bold'
-              - if library.last_played_at
-                span.text-muted-steam = library.last_played_at&.strftime('%Y年%m月%d日')
-              - else
-                span.text-muted-steam 未プレイ
+            div.p-3.rounded.stat-tile
+              = link_to game_path(library.game) do
+                = image_tag steam_banner_image(library.game), class: 'w-100 rounded mb-2', style: 'height: 100px; object-fit: cover;', onerror: "this.onerror=null;this.src='#{broken_thumbnail_placeholder}'"
+              div.d-flex.justify-content-between.align-items-center
+                = link_to library.game.game_title, game_path(library.game), class: 'link-steam-accent fw-bold'
+                - if library.last_played_at
+                  span.text-muted-steam.small = library.last_played_at&.strftime('%Y年%m月%d日')
+                - else
+                  span.text-muted-steam.small 未プレイ
 
     div.col-lg-6
       div.card.text-white.border-0.h-100

--- a/app/views/statistics/show.html.slim
+++ b/app/views/statistics/show.html.slim
@@ -33,18 +33,23 @@ div.mx-auto.mt-5 style="max-width: 960px;"
           | 全体消化率
         div.fs-4.fw-bold = "#{@cleared_game_count_rate.round(2)}%"
 
-  div.card.text-white.border-0.mb-5 data-controller="snapshot-chart" data-snapshot-chart-labels-value="#{@user_statistic_snapshots.pluck(:recorded_on).to_json}" data-snapshot-chart-prices-value="#{@user_statistic_snapshots.pluck(:total_price).to_json}" data-snapshot-chart-rates-value="#{@user_statistic_snapshots.pluck(:unplayed_rate).to_json}"
-    div.card-header.card-header-color.py-3
-      p.p-1.fs-4.mb-0
-        i.bi.bi-graph-up.me-2
-        | 積みゲー推移
-    div.d-flex.gap-3.px-3.pb-2.card-header-color
-      - [['1週間', 'week'], ['1か月', 'month'], ['半年', 'half_year'], ['1年', 'year'], ['全期間', 'all']].each do |label, key|
-        = link_to label, statistic_path(chart_range: key), class: key == @chart_range ? 'text-white fw-bold' : 'link-steam-accent'
-    div.card-body.card-body-color.p-4
-      div.rounded.p-3 style="background-color: #8b929b; box-shadow: 0 6px 14px rgba(0, 0, 0, 0.35);"
-        canvas data-snapshot-chart-target="canvas"
-      p.small.text-muted-steam.mt-2.mb-0 ※1日1度サイトへアクセス時に積みゲー総額と積みゲー率が記録されます。アクセスがなかった日は記録されません。
+  = turbo_frame_tag "snapshot_chart" do
+    div.card.text-white.border-0.mb-5 data-controller="snapshot-chart" data-snapshot-chart-labels-value="#{@user_statistic_snapshots.pluck(:recorded_on).to_json}" data-snapshot-chart-prices-value="#{@user_statistic_snapshots.pluck(:total_price).to_json}" data-snapshot-chart-rates-value="#{@user_statistic_snapshots.pluck(:unplayed_rate).to_json}"
+      div.card-header.card-header-color.py-3
+        p.p-1.fs-4.mb-0
+          i.bi.bi-graph-up.me-2
+          | 積みゲー推移
+      div.d-flex.flex-wrap.align-items-center.gap-3.px-3.pb-2.card-header-color
+        - [['1週間', 'week'], ['1か月', 'month'], ['半年', 'half_year'], ['1年', 'year'], ['全期間', 'all']].each do |label, key|
+          = link_to label, statistic_path(chart_range: key), class: key == @chart_range ? 'text-white fw-bold' : 'link-steam-accent'
+        - if @chart_range_options.any?
+          = form_with url: statistic_path, method: :get, class: "ms-auto" do |f|
+            = hidden_field_tag :chart_range, @chart_range
+            = select_tag :chart_range_offset, options_for_select(@chart_range_options, @chart_range_offset), class: "form-select form-select-sm w-auto", onchange: "this.form.requestSubmit()"
+      div.card-body.card-body-color.p-4
+        div.rounded.p-3 style="background-color: #8b929b; box-shadow: 0 6px 14px rgba(0, 0, 0, 0.35);"
+          canvas data-snapshot-chart-target="canvas"
+        p.small.text-muted-steam.mt-2.mb-0 ※1日1度サイトへアクセス時に積みゲー総額と積みゲー率が記録されます。アクセスがなかった日は記録されません。
 
   div.row.g-5.mb-5
     div.col-lg-6

--- a/app/views/statistics/show.html.slim
+++ b/app/views/statistics/show.html.slim
@@ -34,7 +34,7 @@ div.mx-auto.mt-5 style="max-width: 960px;"
         div.fs-4.fw-bold = "#{@cleared_game_count_rate.round(2)}%"
 
   = turbo_frame_tag "snapshot_chart" do
-    div.card.text-white.border-0.mb-5 data-controller="snapshot-chart" data-snapshot-chart-labels-value="#{@user_statistic_snapshots.pluck(:recorded_on).to_json}" data-snapshot-chart-prices-value="#{@user_statistic_snapshots.pluck(:total_price).to_json}" data-snapshot-chart-rates-value="#{@user_statistic_snapshots.pluck(:unplayed_rate).to_json}"
+    div.card.text-white.border-0.mb-5 data-controller="snapshot-chart" data-snapshot-chart-labels-value="#{@chart_labels.to_json}" data-snapshot-chart-prices-value="#{@chart_prices.to_json}" data-snapshot-chart-rates-value="#{@chart_rates.to_json}"
       div.card-header.card-header-color.py-3
         p.p-1.fs-4.mb-0
           i.bi.bi-graph-up.me-2

--- a/app/views/statistics/show.html.slim
+++ b/app/views/statistics/show.html.slim
@@ -53,18 +53,14 @@ div.mx-auto.mt-5 style="max-width: 960px;"
           p.p-1.fs-4.mb-0
             i.bi.bi-play-circle-fill.me-2
             | ネクストプレイ提案
-        div.d-flex.justify-content-between.px-3.card-header-color
-          span ゲームタイトル
-          span 最終プレイ日
-        div.card-body.card-body-color
-          ol.w-100.px-3
-            - @recommended_games.each do |library|
-              li.d-flex.justify-content-between
-                span = link_to library.game.game_title, game_path(library.game), class: 'link-steam-accent'
-                - if library.last_played_at
-                  span = library.last_played_at&.strftime('%Y年%m月%d日')
-                - else
-                  span 未プレイ
+        div.card-body.card-body-color.d-flex.flex-column.gap-3
+          - @recommended_games.each do |library|
+            div.p-3.rounded.stat-tile.d-flex.justify-content-between.align-items-center
+              = link_to library.game.game_title, game_path(library.game), class: 'link-steam-accent fs-5 fw-bold'
+              - if library.last_played_at
+                span.text-muted-steam = library.last_played_at&.strftime('%Y年%m月%d日')
+              - else
+                span.text-muted-steam 未プレイ
 
     div.col-lg-6
       div.card.text-white.border-0.h-100

--- a/app/views/statistics/show.html.slim
+++ b/app/views/statistics/show.html.slim
@@ -45,7 +45,7 @@ div.mx-auto.mt-5 style="max-width: 960px;"
         - if @chart_range_options.any?
           = form_with url: statistic_path, method: :get, class: "ms-auto" do |f|
             = hidden_field_tag :chart_range, @chart_range
-            = select_tag :chart_range_offset, options_for_select(@chart_range_options, @chart_range_offset), class: "form-select form-select-sm w-auto", onchange: "this.form.requestSubmit()"
+            = select_tag :chart_range_offset, options_for_select(@chart_range_options, @chart_range_offset), class: "form-select form-select-sm w-auto search-input", onchange: "this.form.requestSubmit()"
       div.card-body.card-body-color.p-4
         div.rounded.p-3 style="background-color: #8b929b; box-shadow: 0 6px 14px rgba(0, 0, 0, 0.35);"
           canvas data-snapshot-chart-target="canvas"
@@ -59,16 +59,18 @@ div.mx-auto.mt-5 style="max-width: 960px;"
             i.bi.bi-play-circle-fill.me-2
             | ネクストプレイ提案
         div.card-body.card-body-color.d-flex.flex-column.gap-3
+          - if @no_backlog
+            p.text-center.text-muted-steam.mb-0 積みゲーがありません！素晴らしいゲームライブラリです！
           - @recommended_games.each do |library|
             div.p-3.rounded.stat-tile
               = link_to game_path(library.game) do
                 = image_tag steam_banner_image(library.game), class: 'w-100 rounded mb-2', style: 'height: 100px; object-fit: cover;', onerror: "this.onerror=null;this.src='#{broken_thumbnail_placeholder}'"
-              div.d-flex.justify-content-between.align-items-center
+              div
                 = link_to library.game.game_title, game_path(library.game), class: 'link-steam-accent fw-bold'
                 - if library.last_played_at
-                  span.text-muted-steam.small = library.last_played_at&.strftime('%Y年%m月%d日')
+                  div.text-muted-steam.small = "最終プレイ：#{library.last_played_at&.strftime('%Y年%m月%d日')}"
                 - else
-                  span.text-muted-steam.small 未プレイ
+                  div.text-muted-steam.small 最終プレイ：未プレイ
 
     div.col-lg-6
       div.card.text-white.border-0.h-100
@@ -76,15 +78,31 @@ div.mx-auto.mt-5 style="max-width: 960px;"
           p.p-1.fs-4.mb-0
             i.bi.bi-lightbulb-fill.me-2
             | 逆レコメンド
-        div.card-body.card-body-color
+        div.card-body.card-body-color.d-flex.flex-column.gap-3
+          - if @no_backlog
+            p.text-center.text-muted-steam.mb-0 積みゲーがありません！素晴らしいゲームライブラリです！
           - @most_unplayed_game_genres.each do |genre|
-            p.mb-1 一番詰んでるゲームジャンルは#{genre[0]}で、#{genre[1]}個積んでるよ～
-            p.mb-3
-              = link_to "#{genre[0]}ゲームを探す", steam_genre_name_search(genre[0]), target: :_blank, rel: "noopener noreferrer"
+            div.p-3.rounded.stat-tile
+              - example_game = @genre_example_games[genre[0]]
+              - if example_game
+                = link_to game_path(example_game) do
+                  = image_tag steam_banner_image(example_game), class: 'w-100 rounded mb-2', style: 'height: 80px; object-fit: cover;', onerror: "this.onerror=null;this.src='#{broken_thumbnail_placeholder}'"
+              div.small.text-muted-steam
+                i.bi.bi-graph-up-arrow.me-1
+                | 最も詰んでいるゲーム数の多いジャンル
+              div.fs-5.fw-bold.mb-1 = "#{genre[0]}(#{genre[1]}個)"
+              = link_to "#{genre[0]}ゲームを探す", steam_genre_name_search(genre[0]), target: :_blank, rel: "noopener noreferrer", class: 'link-steam-accent small'
           - @least_unplayed_game_genres.each do |genre|
-            p.mb-1 一番詰んでないゲームジャンルは#{genre[0]}で、#{genre[1]}個積んでるよ～
-            p.mb-0
-              = link_to "#{genre[0]}ゲームを探す", steam_genre_name_search(genre[0]), target: :_blank, rel: "noopener noreferrer"
+            div.p-3.rounded.stat-tile
+              - example_game = @genre_example_games[genre[0]]
+              - if example_game
+                = link_to game_path(example_game) do
+                  = image_tag steam_banner_image(example_game), class: 'w-100 rounded mb-2', style: 'height: 80px; object-fit: cover;', onerror: "this.onerror=null;this.src='#{broken_thumbnail_placeholder}'"
+              div.small.text-muted-steam
+                i.bi.bi-graph-down-arrow.me-1
+                | 最も詰んでいるゲーム数の少ないジャンル
+              div.fs-5.fw-bold.mb-1 = "#{genre[0]}(#{genre[1]}個)"
+              = link_to "#{genre[0]}ゲームを探す", steam_genre_name_search(genre[0]), target: :_blank, rel: "noopener noreferrer", class: 'link-steam-accent small'
 
   div.row.g-5.mb-5
     div.col-lg-6
@@ -98,14 +116,17 @@ div.mx-auto.mt-5 style="max-width: 960px;"
           span.col-5 プレイ時間
           span.col-3 クリア
         div.card-body.card-body-color
-          = form_with url: update_cleared_games_statistic_path, method: :patch do |f|
-            ol.w-100.px-3
-              - @unplayed_games.each do |library|
-                li.d-flex.justify-content-between
-                  span.col-6 = link_to library.game.game_title, game_path(library.game), class: 'link-steam-accent'
-                  span.col-6 = "#{(library.minutes_played/60.0).round(1)}時間"
-                  span.col-6 = check_box_tag "cleared_game_ids[]", library.id
-            = f.submit "更新する"
+          - if @no_backlog
+            p.text-center.text-muted-steam.mb-0 積みゲーがありません！素晴らしいゲームライブラリです！
+          - else
+            = form_with url: update_cleared_games_statistic_path, method: :patch do |f|
+              ol.w-100.px-3
+                - @unplayed_games.each do |library|
+                  li.d-flex.justify-content-between
+                    span.col-6 = link_to library.game.game_title, game_path(library.game), class: 'link-steam-accent'
+                    span.col-6 = "#{(library.minutes_played/60.0).round(1)}時間"
+                    span.col-6 = check_box_tag "cleared_game_ids[]", library.id
+              = f.submit "更新する"
 
     div.col-lg-6
       div.card.text-white.border-0.h-100

--- a/app/views/user_game_libraries/_total_price.html.slim
+++ b/app/views/user_game_libraries/_total_price.html.slim
@@ -1,6 +1,8 @@
 span#total_price
-    - if UserGameLibrary.any_library_game_prices_nil?(user)
+    - if user.user_game_libraries.empty?
+        span.fs-3 積みゲーが同期されていません。ライブラリにゲームが存在すること、Steamのプロフィール設定で「ゲームの詳細」が公開になっているかをご確認ください。
+    - elsif UserGameLibrary.any_library_game_prices_nil?(user)
         span.fs-3 計算中…
         span.loader
     - else
-        = number_to_currency(total_price, precision: 0, unit: '¥')
+        = number_to_currency(total_price, precision: 0, unit: '¥', format: '%u%n')

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -1,14 +1,15 @@
 = turbo_stream_from current_user
 
-p.text-center.fs-1.mt-5.mb-0 あなたの積みゲー総額は
-div.text-center.price-display.fw-bold.mt-0
-    = render "user_game_libraries/total_price", total_price: @total_price, user: @user
+div.text-white.py-5.mt-5.position-relative style="background-color: #16202d;"
+    div.text-center
+        p.fs-3.mb-0.text-muted-steam あなたの積みゲー総額は
+        div.price-display.fw-bold.mt-0
+            = render "user_game_libraries/total_price", total_price: @total_price, user: @user
 
-= render "user_characters/character_display", character_text: @character_text, character_expression: @character_expression
+        div.d-flex.justify-content-center.align-items-center.gap-3 style="margin-top: 5rem;"
+            = button_to "積みゲー統計へ", statistic_path, method: :get, class: "btn btn-steam-primary"
+            = link_to "https://twitter.com/share?url=#{user_share_url(id: current_user.id)}&text=総積み金額は#{@total_price}円！", class: "btn-steam-share" do
+                i class="fa-brands fa-x-twitter"
 
-div.text-center.mt-5
-    = button_to "積みゲー統計へ", statistic_path, method: :get, class: "btn btn-color text-white"
-
-div.text-center.mt-5 class="twitter"
-    = link_to "https://twitter.com/share?url=#{user_share_url(id: current_user.id)}&text=総積み金額は#{@total_price}円！" do
-        i class="fa-brands fa-x-twitter"
+    div style="position: absolute; right: 5rem; top: 50%; transform: translateY(-50%);"
+        = render "user_characters/character_display", character_text: @character_text, character_expression: @character_expression


### PR DESCRIPTION
## 概要
Steam公式サイトの配色に寄せる形でのUI/UXブラッシュアップ。今回のPRでは以下のページ・要素まで対応済み。

## 対応済み
- ヘッダー・フッター(sticky footer化)
- トップページ(サービス紹介、FAQ、ログインボタン、ランキング)
- ユーザーページ(総額表示、キャラクター配置)
- 統計ページ(サマリータイル、期間切り替え付きグラフ、ネクストプレイ提案、逆レコメンド)
- 積みゲー推移グラフの期間切り替え機能(#173)
- ネクストプレイ提案から「次にプレイに設定」ボタン追加(#175)

## 未対応(別PRで継続)
- 統計ページ（積みゲーリスト、コスパランキング、一度積んでからクリアしたゲーム一覧）
- ゲーム一覧のカード見出し
- ゲーム詳細ページ
- マイレージショップ / プレゼント / タスク一覧・詳細
- キャラクター交流ページ
- お問い合わせ / 利用規約・プライバシーポリシー