### PR TITLE
add:コスパランキング詳細ページのデザイン調整

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -38,6 +38,72 @@ body {
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
 }
 
+.cost-performance-row {
+    padding: 1rem 0;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+
+    &:last-child {
+        border-bottom: none;
+    }
+
+    &.rank-1 {
+        background: linear-gradient(90deg, #6b5a1e, #4a3d12);
+        border-radius: 6px;
+    }
+
+    &.rank-2 {
+        background: linear-gradient(90deg, #5a5a5e, #3d3d40);
+        border-radius: 6px;
+    }
+
+    &.rank-3 {
+        background: linear-gradient(90deg, #6b4226, #4a2d18);
+        border-radius: 6px;
+    }
+}
+
+.cost-performance-rank {
+    width: 2.5rem;
+    flex-shrink: 0;
+    text-align: center;
+
+    .rank-crown {
+        display: block;
+        margin: 0 auto;
+    }
+
+    .rank-number {
+        display: block;
+        font-weight: bold;
+    }
+}
+
+.cost-performance-bar-track {
+    margin-right: 3.5rem;
+    height: 1.5rem;
+    background: rgba(255, 255, 255, 0.08);
+    border-radius: 3px;
+    overflow: hidden;
+}
+
+.cost-performance-bar-fill {
+    height: 100%;
+    min-width: 3rem;
+    background: linear-gradient(90deg, #67c1f5, #2a6fa8);
+    border-radius: 3px;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    padding-right: 0.5rem;
+
+    .cost-performance-bar-label {
+        color: #fff;
+        font-size: 0.8rem;
+        font-weight: bold;
+        white-space: nowrap;
+    }
+}
+
 .btn-steam-share {
     display: inline-flex;
     align-items: center;

--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -40,8 +40,9 @@ class StatisticsController < ApplicationController
   end
 
   def cost_performance_detailed_ranking
-    cost_performance_ranking = UserGameLibrary.cost_performance_ranking(current_user)
-    @all_cost_performance_games = cost_performance_ranking[:all]
+    ranked_games = UserGameLibrary.cost_performance_ranking(current_user)[:all]
+    @max_cost_performance_score = ranked_games.first&.cost_performance_score || 0
+    @all_cost_performance_games = Kaminari.paginate_array(ranked_games).page(params[:page])
   end
 
   def update_cleared_games

--- a/app/helpers/statistics_helper.rb
+++ b/app/helpers/statistics_helper.rb
@@ -26,4 +26,20 @@ module StatisticsHelper
     def steam_genre_name_search(genre_name)
         "https://store.steampowered.com/genre/#{STEAM_GENRE_URL_SLUGS[genre_name]}"
     end
+
+    RANK_CROWN_STYLES = {
+        1 => { size: 28, color: '#e6c14d', gems: true },
+        2 => { size: 22, color: '#c7ccd1', gems: false },
+        3 => { size: 18, color: '#c98a4b', gems: false }
+    }.freeze
+
+    def rank_crown(rank)
+        style = RANK_CROWN_STYLES[rank]
+        return nil unless style
+
+        content_tag :svg, viewBox: '0 0 24 24', width: style[:size], height: style[:size], fill: style[:color], class: 'rank-crown' do
+            gems = style[:gems] ? tag.g(fill: '#fff') { tag.circle(cx: 4, cy: 9, r: 1.1) + tag.circle(cx: 12, cy: 6, r: 1.1) + tag.circle(cx: 20, cy: 9, r: 1.1) } : ''
+            tag.path(d: 'M2 20h20l-2-11-5 4-3-7-3 7-5-4-2 11z') + gems
+        end
+    end
 end

--- a/app/models/user_game_library.rb
+++ b/app/models/user_game_library.rb
@@ -59,6 +59,10 @@ class UserGameLibrary < ApplicationRecord
     }
   end
 
+  def cost_performance_score
+    ((minutes_played + 1).to_f / game.price * 1000).round(2)
+  end
+
   def self.total_price(user)
     user.user_game_libraries.unplayed.joins(:game).sum('games.price')
   end

--- a/app/views/statistics/cost_performance_detailed_ranking.html.slim
+++ b/app/views/statistics/cost_performance_detailed_ranking.html.slim
@@ -1,11 +1,30 @@
-div.card.text-white.w-50.border-0.mx-auto.mt-5
-  div.card-header.card-header-color.pb-0
-    p.p-1 コスパランキング
-  div.card-body.card-body-color.d-flex
-    ol.w-100.px-3
-      - @all_cost_performance_games.each do |library|
-        li.d-flex.justify-content-between
-          span.col-6 = library.game.game_title
-          span.col-6 = "¥#{library.game.price}"
-          span.col-6 = "#{(library.minutes_played/60.0).round(1)}時間"
-          span.col-6 = "#{(((library.minutes_played + 1).to_f / library.game.price)*1000).round(2)}"
+div.card.text-white.border-0.mx-auto.mt-5.mb-5.w-75
+  div.card-header.card-header-color.py-3
+    div.d-flex.justify-content-between.align-items-center
+      p.p-1.fs-4.mb-0
+        i.bi.bi-bar-chart-line-fill.me-2
+        | コスパランキング
+      = link_to '統計ページに戻る', statistic_path, class: 'link-steam-accent'
+    p.text-muted-steam.small.px-1.mb-0 各ゲーム下の数値は価格とプレイ時間をもとに算出したコスパ指数です
+
+  div.card-body.card-body-color
+    ol.list-unstyled.px-3.mb-0
+      - @all_cost_performance_games.each_with_index do |library, index|
+        - rank = @all_cost_performance_games.offset_value + index + 1
+        li.cost-performance-row class=("rank-#{rank}" if rank <= 3)
+          div.d-flex.align-items-start.gap-3
+            div.cost-performance-rank
+              - if rank <= 3
+                = rank_crown(rank)
+              span.rank-number = rank
+            div.flex-grow-1
+              div.d-flex.align-items-center.gap-2
+                = link_to game_path(library.game), style: 'width: 80px; flex-shrink: 0;' do
+                  = image_tag steam_thumbnail_image(library.game), class: 'img-fluid rounded', onerror: "this.onerror=null;this.src='#{broken_thumbnail_placeholder}'"
+                div
+                  = link_to library.game.game_title, game_path(library.game), class: 'link-steam-accent small d-block fw-bold'
+                  div.text-muted-steam.small = "¥#{library.game.price} ／ #{(library.minutes_played/60.0).round(1)}時間"
+              div.cost-performance-bar-track.mt-2
+                div.cost-performance-bar-fill style="width: #{[(library.cost_performance_score / @max_cost_performance_score * 100), 100].min}%;"
+                  span.cost-performance-bar-label = library.cost_performance_score
+    = paginate @all_cost_performance_games


### PR DESCRIPTION
## 概要
統計ページの「コスパランキング」詳細ページ(`/statistic/cost_performance_detailed_ranking`)のデザインを調整。

## 変更内容
- ページネーション追加(Kaminari)
- 各行にゲームバナー画像(サムネイル)+タイトルを追加(ネクストプレイ提案と同じ配置)
- コスパ指数を横棒グラフとして可視化(全ゲーム中の最大値に対する相対幅、右端に数値表示)
- 1〜3位に王冠アイコン+行背景に低明度グラデーション
- 行間に薄い罫線、列見出しは廃止しキャプション文言に変更
- コスパ指数の計算式を`UserGameLibrary#cost_performance_score`に集約(重複計算の解消)

## 補足
UI/UXブラッシュアップの継続対応。残りの未対応ページは別PRで継続。