### PR TITLE
add:積みゲーリスト再設計(あなたの積みゲー一覧新設・みんなのゲーム一覧デザイン刷新・クリア機能移設)

### DIFF
--- a/app/controllers/backlogs_controller.rb
+++ b/app/controllers/backlogs_controller.rb
@@ -1,0 +1,33 @@
+class BacklogsController < ApplicationController
+  def show
+    unplayed_games = current_user.user_game_libraries.unplayed.joins(:game).includes(:game)
+    @unplayed_games = case params[:sort]
+    when 'name'
+      unplayed_games.order('games.game_title asc')
+    when 'price_asc'
+      unplayed_games.order('games.price asc')
+    when 'price_desc'
+      unplayed_games.order('games.price desc')
+    else
+      unplayed_games
+    end
+    @no_backlog = @unplayed_games.empty?
+  end
+
+  def update_cleared_game
+    library = current_user.user_game_libraries.find(params[:library_id])
+    library.update!(cleared_date: Time.current)
+    Task.check_and_update_progress!(current_user)
+    redirect_to backlog_path, notice: 'クリア済みにしました。'
+  rescue
+    redirect_to backlog_path, alert: '更新に失敗しました。'
+  end
+
+  def revert_cleared_game
+    library = current_user.user_game_libraries.find(params[:library_id])
+    library.update!(cleared_date: nil)
+    redirect_to backlog_path, notice: '未クリアに戻しました。'
+  rescue
+    redirect_to backlog_path, alert: '更新に失敗しました。'
+  end
+end

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -13,11 +13,11 @@ class GamesController < ApplicationController
         when "price_desc"
             @q.result(distinct: true).order(price: :desc).page(params[:page])
         when "possessed_count"
-            Kaminari.paginate_array(@q.result(distinct: true).all.sort_by{ |game| -(@all_games_count.fetch(game.id, 0)) }).page(params[:page])
+            Kaminari.paginate_array(@q.result(distinct: true).all.sort_by { |game| -(@all_games_count.fetch(game.id, 0)) }).page(params[:page])
         when "unplayed_rate"
-            Kaminari.paginate_array(@q.result(distinct: true).all.sort_by{ |game| -(@all_unplayed_games_count.fetch(game.id, 0).to_f / @all_games_count.fetch(game.id, 0).to_f) }).page(params[:page])
+            Kaminari.paginate_array(@q.result(distinct: true).all.sort_by { |game| -(@all_unplayed_games_count.fetch(game.id, 0).to_f / @all_games_count.fetch(game.id, 0).to_f) }).page(params[:page])
         else
-            Kaminari.paginate_array(@q.result(distinct: true).all.sort_by{ |game| -(@all_games_count.fetch(game.id, 0)) }).page(params[:page])
+            Kaminari.paginate_array(@q.result(distinct: true).all.sort_by { |game| -(@all_games_count.fetch(game.id, 0)) }).page(params[:page])
         end
     end
 
@@ -37,5 +37,21 @@ class GamesController < ApplicationController
         @average_unplayed_time = UserGameLibrary.game_statistics_average_unplayed_time(@game)
 
         @current_user_game = @user.user_game_libraries.find_by(game_id: @game.id)
+    end
+
+    def update_cleared_game
+        library = current_user.user_game_libraries.find_by!(game_id: params[:id])
+        library.update!(cleared_date: Time.current)
+        redirect_to game_path(params[:id]), notice: 'クリア済みにしました。'
+    rescue
+        redirect_to game_path(params[:id]), alert: '更新に失敗しました。'
+    end
+
+    def revert_cleared_game
+        library = current_user.user_game_libraries.find_by!(game_id: params[:id])
+        library.update!(cleared_date: nil)
+        redirect_to game_path(params[:id]), notice: '未クリアに戻しました。'
+    rescue
+        redirect_to game_path(params[:id]), alert: '更新に失敗しました。'
     end
 end

--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -6,8 +6,9 @@ class StatisticsController < ApplicationController
   def show
     @user = current_user
     @total_price = UserGameLibrary.total_price(current_user)
-    @unplayed_games = current_user.user_game_libraries.unplayed.includes(:game)# .limit(UserGameLibrary::TSUMIGE_LIST_LIMIT)
+    @unplayed_games = current_user.user_game_libraries.unplayed.includes(:game)
     @no_backlog = @unplayed_games.empty?
+    @tsumige_list = @unplayed_games.joins(:game).order('games.price DESC').limit(UserGameLibrary::TSUMIGE_LIST_LIMIT)
     @total_games_count = current_user.user_game_libraries.count
     @unplayed_rate = UserGameLibrary.unplayed_rate(current_user)
     @recommended_games = current_user.user_game_libraries.unplayed.cheapest_games.recommend_3
@@ -17,10 +18,10 @@ class StatisticsController < ApplicationController
     @cleared_game_count_rate = UserGameLibrary.cleared_game_count_rate(current_user)
 
     game_genres = UserGameLibrary.unplayed_game_genres(current_user)
-    max_count = game_genres.map{ |x| x[1] }.max
-    min_count = game_genres.map{ |x| x[1] }.min
-    @most_unplayed_game_genres = game_genres.select{ |x| x[1] == max_count }
-    @least_unplayed_game_genres = game_genres.select{ |x| x[1] == min_count }
+    max_count = game_genres.map { |x| x[1] }.max
+    min_count = game_genres.map { |x| x[1] }.min
+    @most_unplayed_game_genres = game_genres.select { |x| x[1] == max_count }
+    @least_unplayed_game_genres = game_genres.select { |x| x[1] == min_count }
     @genre_example_games = (@most_unplayed_game_genres + @least_unplayed_game_genres).each_with_object({}) do |(genre_name, _count), hash|
       hash[genre_name] = current_user.user_game_libraries.unplayed.joins(game: :game_genre_types).find_by(game_genre_types: { name: genre_name })&.game
     end
@@ -44,36 +45,16 @@ class StatisticsController < ApplicationController
     @all_cost_performance_games = cost_performance_ranking[:all]
   end
 
-  def update_cleared_games
-    @user_game_library = current_user.user_game_libraries
-
-    if params[:cleared_game_ids].nil? #チェックなしの場合はreturnでメソッドを強制終了
-      redirect_to statistic_path, alert: 'クリア済みゲームが選択されていません。'
-      return
-    end
-
-    params[:cleared_game_ids].each do |id|
-      @user_game_library.find(id).update!(cleared_date: Time.current)
-    end
-
-    Task.check_and_update_progress!(current_user)
-
-    redirect_to statistic_path, notice: 'クリア済みゲームを更新しました。'
-
-  rescue #update!で例外エラーが発生したときの処理 beginが省略されている rescue単体にendは不要
-    redirect_to statistic_path, alert: 'クリア済みゲームの更新に失敗しました。'
-  end
-
   private
 
   def chart_series(snapshots, start_date, end_date)
-    return [snapshots.pluck(:recorded_on), snapshots.pluck(:total_price), snapshots.pluck(:unplayed_rate)] unless start_date
+    return [ snapshots.pluck(:recorded_on), snapshots.pluck(:total_price), snapshots.pluck(:unplayed_rate) ] unless start_date
 
     snapshots_by_date = snapshots.index_by(&:recorded_on)
     dates = (start_date..end_date).to_a
     prices = dates.map { |date| snapshots_by_date[date]&.total_price }
     rates = dates.map { |date| snapshots_by_date[date]&.unplayed_rate }
-    [dates, prices, rates]
+    [ dates, prices, rates ]
   end
 
   def chart_range_period(range, offset)
@@ -81,19 +62,19 @@ class StatisticsController < ApplicationController
     case range
     when 'week'
       start_date = today.beginning_of_week - offset.weeks
-      [start_date, start_date.end_of_week]
+      [ start_date, start_date.end_of_week ]
     when 'month'
       start_date = today.beginning_of_month - offset.months
-      [start_date, start_date.end_of_month]
+      [ start_date, start_date.end_of_month ]
     when 'half_year'
       current_half_start = today.month <= 6 ? today.beginning_of_year : today.beginning_of_year + 6.months
       start_date = current_half_start - (offset * 6).months
-      [start_date, start_date + 6.months - 1.day]
+      [ start_date, start_date + 6.months - 1.day ]
     when 'year'
       start_date = today.beginning_of_year - offset.years
-      [start_date, start_date.end_of_year]
+      [ start_date, start_date.end_of_year ]
     else
-      [nil, nil]
+      [ nil, nil ]
     end
   end
 
@@ -102,7 +83,7 @@ class StatisticsController < ApplicationController
 
     (0...CHART_RANGE_OFFSET_OPTIONS_COUNT).map do |offset|
       start_date, end_date = chart_range_period(range, offset)
-      [chart_range_period_label(range, start_date, end_date), offset]
+      [ chart_range_period_label(range, start_date, end_date), offset ]
     end
   end
 

--- a/app/views/backlogs/show.html.slim
+++ b/app/views/backlogs/show.html.slim
@@ -1,0 +1,40 @@
+div.card.text-white.border-0.mx-auto.mt-5.card-body-color style="max-width: 720px;"
+  div.card-header.card-header-color.py-3
+    p.p-1.fs-4.mb-0
+      i.bi.bi-hourglass-split.me-2
+      | あなたの積みゲー一覧
+    - current_sort = params[:sort].presence
+    div.d-flex.gap-3.mt-2
+      - [['名前順', 'name'], ['価格の安い順', 'price_asc'], ['価格の高い順', 'price_desc']].each do |label, key|
+        = link_to label, backlog_path(sort: key), class: key == current_sort ? 'text-white fw-bold' : 'link-steam-accent'
+  div.card-body.card-body-color
+    - if @no_backlog
+      p.text-center.text-muted-steam.mb-0 積みゲーがありません！素晴らしいゲームライブラリです！
+    - else
+      div.px-3
+        div.py-1.rounded.stat-tile.d-flex.text-center
+          span.fw-bold style="flex: 1 1 0;" ゲーム
+          span.fw-bold style="flex: 1 1 0;" プレイ時間
+          span.fw-bold style="flex: 1 1 0;" 価格
+          span.fw-bold style="flex: 1 1 0;" クリア
+      ol.list-unstyled.w-100.px-3
+        - @unplayed_games.each do |library|
+          li.mt-3
+            div.d-flex.align-items-center
+              div.text-center style="flex: 1 1 0;"
+                = link_to game_path(library.game) do
+                  = image_tag steam_banner_image(library.game), class: 'rounded', style: 'width: 200px; height: 80px; object-fit: cover;', onerror: "this.onerror=null;this.src='#{broken_thumbnail_placeholder}'"
+              span.text-center style="flex: 1 1 0;" = "#{(library.minutes_played/60.0).round(1)}時間"
+              span.text-center style="flex: 1 1 0;" = "¥#{library.game.price}"
+              span.text-center style="flex: 1 1 0;"
+                - if library.cleared_date
+                  = button_to '未クリアに戻す', revert_cleared_game_backlog_path(library_id: library.id), method: :patch, class: 'btn btn-color text-white btn-sm'
+                - else
+                  = button_to 'クリア済みにする', update_cleared_game_backlog_path(library_id: library.id), method: :patch, class: 'btn btn-color text-white btn-sm', form: { data: { turbo_confirm: "「#{library.game.game_title}」をクリア済みにしますか?" } }
+            div.d-flex
+              div.text-center style="flex: 1 1 0;"
+                div.d-inline-block.text-start style="width: 200px;"
+                  = link_to library.game.game_title, game_path(library.game), class: 'link-steam-accent small d-block mt-1'
+              span style="flex: 1 1 0;"
+              span style="flex: 1 1 0;"
+              span style="flex: 1 1 0;"

--- a/app/views/games/index.html.slim
+++ b/app/views/games/index.html.slim
@@ -1,23 +1,28 @@
-div.card.text-white.w-50.border-0.mx-auto.mt-5
-  div.card-header.card-header-color.pb-0
-    p.p-1 ゲーム一覧
-  div.d-flex.gap-3.px-3.pb-2.card-header-color
-    = link_to '名前順', games_path(sort: 'name'), class: 'link-steam-accent'
-    = link_to '価格の安い順', games_path(sort: 'price_asc'), class: 'link-steam-accent'
-    = link_to '価格の高い順', games_path(sort: 'price_desc'), class: 'link-steam-accent'
-    = link_to '積み率順', games_path(sort: 'unplayed_rate'), class: 'link-steam-accent'
-    = link_to '所持者数順', games_path(sort: 'possessed_count'), class: 'link-steam-accent'
-  div.d-flex.justify-content-between.px-3.card-header-color
-    span.col-3 ゲームタイトル
-    span.col-2 所持者数
-    span.col-2 積み率
-    span.col-5 サムネ
+div.card.text-white.w-50.border-0.mx-auto.mt-5.card-body-color
+  div.card-header.card-header-color.py-3
+    p.p-1.fs-4.mb-0
+      i.bi.bi-people-fill.me-2
+      | みんなのゲーム一覧
+    - current_sort = params[:sort].presence || 'possessed_count'
+    div.d-flex.gap-3.mt-2
+      - [['名前順', 'name'], ['価格の安い順', 'price_asc'], ['価格の高い順', 'price_desc'], ['積み率順', 'unplayed_rate'], ['所持者数順', 'possessed_count']].each do |label, key|
+        = link_to label, games_path(sort: key), class: key == current_sort ? 'text-white fw-bold' : 'link-steam-accent'
   div.card-body.card-body-color
+    div.px-3
+      div.py-1.rounded.stat-tile.d-flex.text-center
+        span.fw-bold style="flex: 1 1 0;" ゲーム
+        span.fw-bold style="flex: 1 1 0;" 所持者数
+        span.fw-bold style="flex: 1 1 0;" 価格
+        span.fw-bold style="flex: 1 1 0;" 積み率
     ol.w-100.px-3
       - @games.each do |game|
-        li.d-flex.justify-content-between.align-items-center.mt-3
-          span.col-3 = link_to game.game_title, game_path(game), class: 'link-steam-accent'
-          span.col-2 = "#{@all_games_count.fetch(game.id, 0)}人"
-          span.col-2 = "#{((@all_unplayed_games_count.fetch(game.id, 0).to_f / @all_games_count.fetch(game.id, 0).to_f) * 100).round(1)}%"
-          span.col-5 = image_tag steam_thumbnail_image(game), class: 'img-fluid', onerror: "this.onerror=null;this.src='#{broken_thumbnail_placeholder}'"
+        li.d-flex.align-items-center.mt-3
+          div.text-center style="flex: 1 1 0;"
+            div.d-inline-block.text-start style="width: 200px;"
+              = link_to game_path(game) do
+                = image_tag steam_banner_image(game), class: 'rounded mb-1', style: 'width: 200px; height: 80px; object-fit: cover;', onerror: "this.onerror=null;this.src='#{broken_thumbnail_placeholder}'"
+              = link_to game.game_title, game_path(game), class: 'link-steam-accent small d-block'
+          span.text-center style="flex: 1 1 0;" = "#{@all_games_count.fetch(game.id, 0)}人"
+          span.text-center style="flex: 1 1 0;" = "¥#{game.price}"
+          span.text-center style="flex: 1 1 0;" = "#{((@all_unplayed_games_count.fetch(game.id, 0).to_f / @all_games_count.fetch(game.id, 0).to_f) * 100).round(1)}%"
     = paginate @games

--- a/app/views/games/show.html.slim
+++ b/app/views/games/show.html.slim
@@ -8,6 +8,13 @@ div.card.text-white.w-50.border-0.mx-auto.mt-5
     p.me-4 価格: #{number_to_currency(@game.price, precision: 0, unit: '¥')}
     p.me-4
       = link_to 'Steamストアページへ', steam_store_link(@game), target: :_blank, rel: 'noopener noreferrer', class: 'btn btn-secondary text-white'
+    - if @current_user_game
+      p.me-4
+        - if @current_user_game.cleared_date
+          span.badge.bg-success.me-2 クリア済み
+          = button_to '未クリアに戻す', revert_cleared_game_game_path(@game), method: :patch, class: 'btn btn-secondary text-white'
+        - else
+          = button_to 'クリア済みにする', update_cleared_game_game_path(@game), method: :patch, class: 'btn-steam-primary'
 
 div.card.text-white.w-50.border-0.mx-auto.mt-5
   div.card-header.card-header-color.pb-0

--- a/app/views/layouts/_header.slim
+++ b/app/views/layouts/_header.slim
@@ -11,7 +11,8 @@ nav.navbar.navbar-expand-lg.ps-3.fixed-top
           li
             = link_to '積みゲー総額', user_path, class: 'dropdown-item'
             = link_to '積みゲー統計', statistic_path, class: 'dropdown-item'
-            = link_to 'ゲーム一覧', games_path, class: 'dropdown-item'
+            = link_to 'あなたの積みゲー一覧', backlog_path, class: 'dropdown-item'
+            = link_to 'みんなのゲーム一覧', games_path, class: 'dropdown-item'
             = link_to 'プレイ状況', play_focus_path, class: 'dropdown-item'
 
       div.dropdown.pe-3

--- a/app/views/statistics/show.html.slim
+++ b/app/views/statistics/show.html.slim
@@ -120,20 +120,17 @@ div.mx-auto.mt-5 style="max-width: 960px;"
             | 積みゲーリスト
         div.d-flex.justify-content-between.px-3.card-header-color
           span.col-6 ゲームタイトル
-          span.col-5 プレイ時間
-          span.col-3 クリア
-        div.card-body.card-body-color
+          span.col-6 プレイ時間
+        div.card-body.card-body-color.d-flex.flex-column
           - if @no_backlog
             p.text-center.text-muted-steam.mb-0 積みゲーがありません！素晴らしいゲームライブラリです！
           - else
-            = form_with url: update_cleared_games_statistic_path, method: :patch do |f|
-              ol.w-100.px-3
-                - @unplayed_games.each do |library|
-                  li.d-flex.justify-content-between
-                    span.col-6 = link_to library.game.game_title, game_path(library.game), class: 'link-steam-accent'
-                    span.col-6 = "#{(library.minutes_played/60.0).round(1)}時間"
-                    span.col-6 = check_box_tag "cleared_game_ids[]", library.id
-              = f.submit "更新する"
+            ol.w-100.px-3
+              - @tsumige_list.each do |library|
+                li.d-flex.justify-content-between
+                  span.col-6 = link_to library.game.game_title, game_path(library.game), class: 'link-steam-accent'
+                  span.col-6 = "#{(library.minutes_played/60.0).round(1)}時間"
+            = link_to '積みゲー一覧を見る', backlog_path, class: 'btn-steam-primary align-self-start mt-2'
 
     div.col-lg-6
       div.card.text-white.border-0.h-100

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   require "sidekiq/web" # require the web UI
   mount Sidekiq::Web => "/sidekiq" # access it at http://localhost:3000/sidekiq
-  
+
   if Rails.env.development?
     mount LetterOpenerWeb::Engine, at: "/letter_opener"
   end
@@ -30,12 +30,22 @@ Rails.application.routes.draw do
     collection do
       get :search_suggestions
     end
+    member do
+      patch :update_cleared_game
+      patch :revert_cleared_game
+    end
   end
 
   resource :statistic, only: %i[show] do
     member do
-      patch 'update_cleared_games'
       get 'cost_performance_detailed_ranking'
+    end
+  end
+
+  resource :backlog, only: %i[show] do
+    member do
+      patch 'update_cleared_game'
+      patch 'revert_cleared_game'
     end
   end
 
@@ -72,7 +82,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :contacts, only: [:new, :create] do
+  resources :contacts, only: [ :new, :create ] do
     collection do
       post 'confirm'
     end


### PR DESCRIPTION
## 概要
積みゲーリストの再設計。「あなたの積みゲー一覧」を新設し、既存ページの役割を整理。

## 変更内容
- 統計ページの積みゲーリストを簡素化(価格上位のみ表示、クリア機能は新ページへ移設)
- 「あなたの積みゲー一覧」ページを新設(`/backlog`)
  - 名前順/価格の安い順/価格の高い順の並べ替え
  - 「クリア済みにする」/「未クリアに戻す」ボタン(確認ダイアログ付き)
- 「ゲーム一覧」を「みんなのゲーム一覧」に改名し、UI/UXを調整
- ゲーム詳細ページに「クリア済みにする」/「未クリアに戻す」ボタンを追加

## 補足
UI/UXブラッシュアップの継続対応。次回は統計ページの残り調整、ゲーム詳細ページの見た目刷新など。